### PR TITLE
fix(runtime): pin selected cloud provider

### DIFF
--- a/packages/core/src/runtime/llm-api.test.ts
+++ b/packages/core/src/runtime/llm-api.test.ts
@@ -99,6 +99,42 @@ describe("LlmApiRuntime provider detection", () => {
     expect(await rt.isAvailable()).toBe(true);
   });
 
+  it("selects Azure Foundry gpt-5.4 before an injected direct DeepSeek failover", async () => {
+    // Test fixtures, literal non-secret keys.
+    // foxguard: ignore[js/no-hardcoded-secret]
+    process.env.DEEPSEEK_API_KEY = "deepseek-fallback-key";
+    // foxguard: ignore[js/no-hardcoded-secret]
+    process.env.AZURE_OPENAI_API_KEY = "azure-primary-key";
+    process.env.AZURE_OPENAI_BASE_URL = "https://example-resource.openai.azure.com/openai/v1";
+    process.env.AZURE_OPENAI_MODEL = "DeepSeek-V4-Pro";
+    process.env.PWNKIT_MODEL = "gpt-5.4";
+
+    const rt = new LlmApiRuntime({ type: "api", timeout: 5000 });
+    const diagnostics = rt.getConfigurationDiagnostics();
+
+    expect(diagnostics.valid).toBe(true);
+    expect(diagnostics.provider).toBe("azure");
+    expect(rt.resolvedModel()).toBe("gpt-5.4");
+    expect(await rt.isAvailable()).toBe(true);
+  });
+
+  it("honors a cloud-selected Azure provider over ambient fallback credentials", async () => {
+    // Test fixtures, literal non-secret keys.
+    // foxguard: ignore[js/no-hardcoded-secret]
+    process.env.DEEPSEEK_API_KEY = "deepseek-fallback-key";
+    // foxguard: ignore[js/no-hardcoded-secret]
+    process.env.AZURE_OPENAI_API_KEY = "azure-primary-key";
+    process.env.AZURE_OPENAI_BASE_URL = "https://example-resource.openai.azure.com/openai/v1";
+    process.env.AZURE_OPENAI_MODEL = "DeepSeek-V4-Pro";
+    process.env.PWNKIT_MODEL = "future-foundry-deployment";
+    process.env.PWNKIT_SELECTED_PROVIDER = "azure";
+
+    const rt = new LlmApiRuntime({ type: "api", timeout: 5000 });
+
+    expect(rt.getConfigurationDiagnostics().provider).toBe("azure");
+    expect(rt.resolvedModel()).toBe("future-foundry-deployment");
+  });
+
   it("selects Anthropic when ANTHROPIC_API_KEY is set", async () => {
     process.env.ANTHROPIC_API_KEY = "sk-ant-test456";
     const rt = new LlmApiRuntime({ type: "api", timeout: 5000 });

--- a/packages/core/src/runtime/llm-api.ts
+++ b/packages/core/src/runtime/llm-api.ts
@@ -565,6 +565,7 @@ const AZURE_FOUNDRY_DEPLOYMENT_IDS: Record<string, true> = {
   "deepseek-v4-pro": true,
   "kimi-k2.7-code": true,
   "gpt-oss-120b": true,
+  "gpt-5.4": true,
   "gpt-5.6-sol": true,
   "gpt-5.6-luna": true,
   "gpt-5.6-terra": true,
@@ -1208,10 +1209,26 @@ function detectProvider(configApiKey?: string, preferredModel?: string): {
     };
   }
 
-  // Controlled benchmark runs bind a manifest's provider identity as well as
-  // its model route. Normal interactive scans retain model-first routing.
+  // Cloud workers hand the selected provider to the sandbox explicitly. This
+  // wins over ambient credential precedence: fallback credentials must never
+  // become the primary merely because their key is also present. The older
+  // FORCE variant remains for controlled benchmark manifests.
+  const selectedProviderRaw = process.env.PWNKIT_SELECTED_PROVIDER?.trim();
   const forcedProviderRaw = process.env.PWNKIT_FORCE_PROVIDER?.trim();
-  if (forcedProviderRaw) {
+  if (
+    selectedProviderRaw &&
+    forcedProviderRaw &&
+    selectedProviderRaw !== forcedProviderRaw
+  ) {
+    throw new Error(
+      "PWNKIT_SELECTED_PROVIDER conflicts with PWNKIT_FORCE_PROVIDER",
+    );
+  }
+  const pinnedProviderRaw = selectedProviderRaw ?? forcedProviderRaw;
+  if (pinnedProviderRaw) {
+    const source = selectedProviderRaw
+      ? "PWNKIT_SELECTED_PROVIDER"
+      : "PWNKIT_FORCE_PROVIDER";
     const supported: readonly ApiProvider[] = [
       "openrouter",
       "anthropic",
@@ -1223,17 +1240,17 @@ function detectProvider(configApiKey?: string, preferredModel?: string): {
       "kimi",
       "qwen",
     ];
-    if (!supported.includes(forcedProviderRaw as ApiProvider)) {
-      throw new Error(`PWNKIT_FORCE_PROVIDER is unsupported: ${forcedProviderRaw}`);
+    if (!supported.includes(pinnedProviderRaw as ApiProvider)) {
+      throw new Error(`${source} is unsupported: ${pinnedProviderRaw}`);
     }
     const model = preferredModel ?? process.env.PWNKIT_MODEL;
     if (!model) {
-      throw new Error("PWNKIT_FORCE_PROVIDER requires an explicit model");
+      throw new Error(`${source} requires an explicit model`);
     }
-    const provider = forcedProviderRaw as ApiProvider;
+    const provider = pinnedProviderRaw as ApiProvider;
     const resolved = resolveFailoverProvider(provider, model);
     if (!resolved) {
-      throw new Error(`PWNKIT_FORCE_PROVIDER=${provider} has no configured credentials`);
+      throw new Error(`${source}=${provider} has no configured credentials`);
     }
     return { provider, ...resolved, defaultModel: model };
   }


### PR DESCRIPTION
## Problem

A cloud caller can supply a provider-specific model selection while the sandbox also receives credentials for other providers. Ambient credential precedence can then select the wrong provider even though the caller already resolved one.

## Change

- Add `gpt-5.4` to the Azure Foundry deployment allowlist.
- Honor `PWNKIT_SELECTED_PROVIDER` before model/ambient credential selection.
- Fail closed when that selection conflicts with benchmark-only `PWNKIT_FORCE_PROVIDER` or lacks an explicit model/credential.

The new variable is a generic, credential-free provider-routing contract. It does not introduce model fallback or publish configuration values, credentials, endpoints, or target data.

## Checks

- `pnpm --filter @pwnkit/core test -- llm-api.test.ts`
- `pnpm --filter @pwnkit/core... build`