### PR TITLE
ci: run public verification on self-hosted runner

### DIFF
--- a/.github/workflows/public-pr.yml
+++ b/.github/workflows/public-pr.yml
@@ -13,19 +13,17 @@ concurrency:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-      - name: Enable pnpm
-        run: corepack enable
+      - name: Bootstrap runner
+        run: bash "$GITHUB_WORKSPACE/scripts/ci-runner-bootstrap.sh"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Install libFuzzer toolchain
-        run: sudo apt-get update && sudo apt-get install --yes clang
       - name: Build CLI
         run: pnpm build
       - name: Type-check


### PR DESCRIPTION
Use the existing runner bootstrap and self-hosted Linux/X64 pool. GitHub-hosted PR runs currently fail before steps because the account billing limit is zero.