### PR TITLE
feat(public): port reproducibility manifest

### DIFF
--- a/packages/cli/src/commands/__tests__/disclose-review.test.ts
+++ b/packages/cli/src/commands/__tests__/disclose-review.test.ts
@@ -1,0 +1,241 @@
+/**
+ * #151 — CLI integration tests for `pwnkit disclose review`.
+ *
+ * Tests the CLI subcommand end-to-end through the real
+ * `registerDiscloseCommand` and `assembleReproducibilityManifest` /
+ * `renderReproducibilityManifest` so the gates and output shape
+ * are genuinely exercised (no module mocks).
+ *
+ * Follows the pattern established in `disclose-evidence-pack.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { registerDiscloseCommand } = await import("../disclose.js");
+
+function captureIO() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const o = vi.spyOn(console, "log").mockImplementation((...a) => stdout.push(a.map(String).join(" ")));
+  const e = vi.spyOn(console, "error").mockImplementation((...a) => stderr.push(a.map(String).join(" ")));
+  return { stdout, stderr, restore: () => { o.mockRestore(); e.mockRestore(); } };
+}
+
+async function runCli(argv: string[]): Promise<void> {
+  const program = new Command();
+  program.exitOverride();
+  registerDiscloseCommand(program);
+  await program.parseAsync(["node", "pwnkit-cli", ...argv]);
+}
+
+function verifiedFinding() {
+  return {
+    id: "f-review-001",
+    templateId: "tpl-sqli",
+    title: "SQL injection in /api/reports",
+    description: "Time-based SQL injection via the date parameter",
+    severity: "critical",
+    category: "sqli",
+    status: "verified",
+    evidence: {
+      request: "GET /api/reports?date=2024-01-01 HTTP/1.1\nAuthorization: Bearer secret-bearer-token\nHost: target.example",
+      response: "HTTP/1.1 200 OK\nSet-Cookie: session=deadbeef\nContent-Type: application/json\n\n[{\"id\":1}]",
+    },
+    pocSteps: [
+      {
+        id: "exploit",
+        kind: "exploit",
+        summary: "SQL injection in GET /api/reports",
+        action: {
+          type: "shell",
+          cmd: "curl -X GET 'https://target.example/api/reports?date=2024-01-01' -H 'Authorization: Bearer secret-bearer-token'",
+        },
+      },
+    ],
+    pocExecution: {
+      findingId: "f-review-001",
+      startedAt: "2026-08-02T11:00:00.000Z",
+      endedAt: "2026-08-02T11:00:05.000Z",
+      steps: [
+        {
+          stepId: "exploit",
+          kind: "passed",
+          durationMs: 3200,
+          observedExit: 0,
+          observedStdout: "200 OK",
+        },
+      ],
+      overallVerdict: "exploit_still_works",
+    },
+    layerVerdicts: [
+      { layer: "oracle", verdict: "pass", reason: "PoC oracle confirms reachability", durationMs: 42, costUsd: 0 },
+      { layer: "skeptic", verdict: "pass", reason: "Skeptic could not refute", durationMs: 120, costUsd: 0 },
+    ],
+    timestamp: 1,
+  };
+}
+
+describe("pwnkit disclose review", () => {
+  let io: ReturnType<typeof captureIO>;
+  let dir: string;
+
+  beforeEach(() => {
+    io = captureIO();
+    dir = mkdtempSync(join(tmpdir(), "disclose-review-test-"));
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    io.restore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("renders the reproducibility manifest to stdout", async () => {
+    const fp = join(dir, "finding.json");
+    writeFileSync(fp, JSON.stringify(verifiedFinding()));
+    await runCli(["disclose", "review", fp, "--timestamp", "2026-08-02T12:00:00.000Z"]);
+
+    const out = io.stdout.join("\n");
+    expect(out).toContain("REPRODUCIBILITY MANIFEST");
+    expect(out).toContain("f-review-001");
+    expect(out).toContain("SQL injection in /api/reports");
+    expect(out).toContain("FOR HUMAN REVIEW ONLY");
+  });
+
+  it("writes the manifest to --out and never sends", async () => {
+    const fp = join(dir, "finding.json");
+    writeFileSync(fp, JSON.stringify(verifiedFinding()));
+    const outPath = join(dir, "manifest.txt");
+    await runCli(["disclose", "review", fp, "--out", outPath, "--timestamp", "2026-08-02T12:00:00.000Z"]);
+
+    const content = readFileSync(outPath, "utf8");
+    expect(content).toContain("REPRODUCIBILITY MANIFEST");
+    expect(content).toContain("f-review-001");
+    expect(content).toContain("FOR HUMAN REVIEW ONLY");
+  });
+
+  it("refuses a non-verified finding", async () => {
+    const finding = { ...verifiedFinding(), status: "discovered" };
+    const fp = join(dir, "finding.json");
+    writeFileSync(fp, JSON.stringify(finding));
+    await runCli(["disclose", "review", fp, "--timestamp", "2026-08-02T12:00:00.000Z"]);
+
+    expect(process.exitCode).toBe(2);
+    expect(io.stderr.join("\n")).toContain('expected "verified" or "confirmed"');
+  });
+
+  it("refuses incomplete evidence (no PoC exec, no layer verdicts)", async () => {
+    const finding = {
+      ...verifiedFinding(),
+      pocExecution: undefined,
+      layerVerdicts: [],
+    };
+    const fp = join(dir, "finding.json");
+    writeFileSync(fp, JSON.stringify(finding));
+    await runCli(["disclose", "review", fp, "--timestamp", "2026-08-02T12:00:00.000Z"]);
+
+    expect(process.exitCode).toBe(2);
+    expect(io.stderr.join("\n")).toContain("successful verified PoV");
+  });
+
+  it("refuses malformed JSON with exit code 2", async () => {
+    const fp = join(dir, "bad.json");
+    writeFileSync(fp, "not json");
+    await runCli(["disclose", "review", fp]);
+
+    expect(process.exitCode).toBe(2);
+    expect(io.stderr.join("\n")).toContain("Failed to read finding JSON");
+  });
+
+  it("never leaks secrets in the rendered output", async () => {
+    const fp = join(dir, "finding.json");
+    writeFileSync(fp, JSON.stringify(verifiedFinding()));
+    await runCli(["disclose", "review", fp, "--timestamp", "2026-08-02T12:00:00.000Z"]);
+
+    const out = io.stdout.join("\n");
+    expect(out).not.toContain("secret-bearer-token");
+    expect(out).not.toContain("deadbeef");
+  });
+
+  it("accepts --target override", async () => {
+    const fp = join(dir, "finding.json");
+    writeFileSync(fp, JSON.stringify(verifiedFinding()));
+    await runCli(["disclose", "review", fp, "--target", "acme-app:1.2.3", "--timestamp", "2026-08-02T12:00:00.000Z"]);
+
+    const out = io.stdout.join("\n");
+    expect(out).toContain("acme-app:1.2.3");
+  });
+
+  it("accepts --tool-version override", async () => {
+    const fp = join(dir, "finding.json");
+    writeFileSync(fp, JSON.stringify(verifiedFinding()));
+    await runCli(["disclose", "review", fp, "--tool-version", "pwnkit/0.2.0-test", "--timestamp", "2026-08-02T12:00:00.000Z"]);
+
+    const out = io.stdout.join("\n");
+    expect(out).toContain("pwnkit/0.2.0-test");
+  });
+
+  it("renders model config when --model-config is provided", async () => {
+    const fp = join(dir, "finding.json");
+    writeFileSync(fp, JSON.stringify(verifiedFinding()));
+    await runCli(["disclose", "review", fp, "--model-config", "anthropic/claude-sonnet-4", "--timestamp", "2026-08-02T12:00:00.000Z"]);
+
+    const out = io.stdout.join("\n");
+    expect(out).toContain("anthropic/claude-sonnet-4");
+  });
+
+  it("strips userinfo from ssh:// targets", async () => {
+    const fp = join(dir, "finding.json");
+    writeFileSync(fp, JSON.stringify(verifiedFinding()));
+    await runCli(["disclose", "review", fp, "--target", "ssh://git:supersecret@github.com/org/repo", "--timestamp", "2026-08-02T12:00:00.000Z"]);
+
+    const out = io.stdout.join("\n");
+    expect(out).not.toContain("supersecret");
+    expect(out).not.toContain("git:");
+    expect(out).toContain("[REDACTED-USER]");
+  });
+
+  it("renders hashes for evidence (not the raw secrets)", async () => {
+    const fp = join(dir, "finding.json");
+    writeFileSync(fp, JSON.stringify(verifiedFinding()));
+    await runCli(["disclose", "review", fp, "--timestamp", "2026-08-02T12:00:00.000Z"]);
+
+    const out = io.stdout.join("\n");
+    // Evidence section should show SHA-256 hex digests, not raw content.
+    expect(out).toMatch(/Request \(SHA-256\)\s+[a-f0-9]{64}/);
+    expect(out).toMatch(/Response \(SHA-256\)\s+[a-f0-9]{64}/);
+  });
+
+  it("reports --out mkdir failure with exit code 2 and no success output", async () => {
+    // Place a regular file where a directory would be needed so that
+    // mkdirSync(dirname(outPath)) throws.
+    const fp = join(dir, "finding.json");
+    writeFileSync(fp, JSON.stringify(verifiedFinding()));
+    const blockFile = join(dir, "block");
+    writeFileSync(blockFile, "");
+    const outPath = join(blockFile, "manifest.txt");
+    await runCli(["disclose", "review", fp, "--out", outPath, "--timestamp", "2026-08-02T12:00:00.000Z"]);
+
+    expect(process.exitCode).toBe(2);
+    expect(io.stdout.join("")).not.toContain("Manifest written");
+    expect(io.stderr.join("")).toBeTruthy();
+  });
+
+  it("reports --out write failure with exit code 2 and no success output", async () => {
+    // Write to an existing directory as the output path — writeFileSync
+    // throws EISDIR when the target is a directory, not a file.
+    const fp = join(dir, "finding.json");
+    writeFileSync(fp, JSON.stringify(verifiedFinding()));
+    const outDir = join(dir, "target-dir");
+    mkdirSync(outDir);
+    await runCli(["disclose", "review", fp, "--out", outDir, "--timestamp", "2026-08-02T12:00:00.000Z"]);
+
+    expect(process.exitCode).toBe(2);
+    expect(io.stdout.join("")).not.toContain("Manifest written");
+    expect(io.stderr.join("")).toBeTruthy();
+  });
+});

--- a/packages/cli/src/commands/disclose.ts
+++ b/packages/cli/src/commands/disclose.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { writeFileSync, mkdirSync, existsSync, readFileSync } from "node:fs";
-import { resolve, join } from "node:path";
+import { resolve, join, dirname } from "node:path";
 import { homedir } from "node:os";
 import chalk from "chalk";
 import type { Finding, AttackCategory, Severity, Evidence, FindingStatus, PocStep } from "@pwnkit/shared";
@@ -37,6 +37,10 @@ import {
   DISCLOSURE_STATUSES,
   type DisclosureRecord,
   type DisclosureStatus,
+  assembleReproducibilityManifest,
+  renderReproducibilityManifest,
+  UnverifiedFindingError,
+  IncompleteEvidenceError,
 } from "@pwnkit/core";
 
 interface DiscloseOptions {
@@ -584,6 +588,14 @@ interface TrackOptions {
   out?: string;
 }
 
+interface ReviewOptions {
+  timestamp?: string;
+  toolVersion?: string;
+  modelConfig?: string;
+  target?: string;
+  out?: string;
+}
+
 /**
  * `disclose track <findingId>` — drive the disclosure tracking state machine.
  * With no `--record`, opens a fresh draft record. With `--record <file> --to
@@ -629,6 +641,36 @@ function discloseTrack(findingId: string, opts: TrackOptions): void {
     return;
   }
   console.log(json);
+}
+
+/**
+ * `disclose review <finding.json>` — render a local reproducibility manifest
+ * for a verified finding. Assembles the manifest from the finding JSON and
+ * renders it to stdout (or --out). Refuses non-verified findings and
+ * incomplete evidence. Never sends or publishes anything.
+ */
+function discloseReview(findingPath: string, opts: ReviewOptions): void {
+  const jsonPath = resolve(findingPath);
+  const raw = readFileSync(jsonPath, "utf8");
+  const finding = JSON.parse(raw) as Finding;
+  const manifest = assembleReproducibilityManifest(finding, {
+    timestamp: opts.timestamp,
+    toolVersion: opts.toolVersion,
+    modelConfig: opts.modelConfig,
+    targetIdentifier: opts.target,
+  });
+  const rendered = renderReproducibilityManifest(manifest);
+  if (opts.out) {
+    const outPath = resolve(opts.out);
+    const outDir = dirname(outPath);
+    if (!existsSync(outDir)) {
+      mkdirSync(outDir, { recursive: true });
+    }
+    writeFileSync(outPath, rendered + "\n", "utf8");
+    console.log(`Manifest written to ${outPath}`);
+  } else {
+    console.log(rendered);
+  }
 }
 
 export function registerDiscloseCommand(program: Command): void {
@@ -689,5 +731,35 @@ export function registerDiscloseCommand(program: Command): void {
     .option("--out <file>", "Write the record JSON to a file instead of stdout")
     .action((findingId: string, opts: TrackOptions) => {
       discloseTrack(findingId, opts);
+    });
+
+  discloseCmd
+    .command("review")
+    .description(
+      "Render a local reproducibility manifest for a verified finding. " +
+      "The manifest is deterministic, redacted, and safe for human inspection. " +
+      "Never sends or publishes anything.",
+    )
+    .argument("<finding.json>", "Path to a Finding JSON file")
+    .option("--timestamp <iso>", "Override generation timestamp for deterministic output")
+    .option("--tool-version <ver>", "Override tool version string")
+    .option("--model-config <str>", "Provider/model config, e.g. anthropic/claude-sonnet-4")
+    .option("--target <id>", "Override the finding target identifier")
+    .option("--out <file>", "Write manifest to a file instead of stdout")
+    .action((findingPath: string, opts: ReviewOptions) => {
+      try {
+        discloseReview(findingPath, opts);
+      } catch (err) {
+        if (err instanceof UnverifiedFindingError || err instanceof IncompleteEvidenceError) {
+          console.error(chalk.red(err.message));
+          process.exitCode = 2;
+        } else if (err instanceof SyntaxError && err.message.includes("JSON")) {
+          console.error(chalk.red(`Failed to read finding JSON: ${(err as Error).message}`));
+          process.exitCode = 2;
+        } else {
+          console.error(chalk.red(String(err)));
+          process.exitCode = 2;
+        }
+      }
     });
 }

--- a/packages/core/src/disclose/index.ts
+++ b/packages/core/src/disclose/index.ts
@@ -82,3 +82,13 @@ export type {
   KnownMarker,
   KnownMarkerSignal,
 } from "./known-marker.js";
+export {
+  assembleReproducibilityManifest,
+  renderReproducibilityManifest,
+  UnverifiedFindingError,
+  IncompleteEvidenceError,
+} from "./reproducibility-manifest.js";
+export type {
+  ReproducibilityManifest,
+  ManifestOptions,
+} from "./reproducibility-manifest.js";

--- a/packages/core/src/disclose/reproducibility-manifest.test.ts
+++ b/packages/core/src/disclose/reproducibility-manifest.test.ts
@@ -1,0 +1,610 @@
+/**
+ * #151 — Deterministic tests for the reproducibility manifest.
+ *
+ * Covers:
+ *   • Deterministic output for a known timestamp + input
+ *   • Rejection of non-verified findings
+ *   • Rejection of findings with incomplete evidence (no PoC exec, no layer verdicts)
+ *   • Redaction-before-hash invariance
+ *   • Evidence hash computation after redaction
+ *   • Render output contains all sections
+ */
+
+import { describe, it, expect } from "vitest";
+import type {
+  Finding,
+  PocStep,
+  LayerVerdict,
+  Evidence,
+  VerificationResult,
+} from "@pwnkit/shared";
+import {
+  assembleReproducibilityManifest,
+  renderReproducibilityManifest,
+  UnverifiedFindingError,
+  IncompleteEvidenceError,
+} from "./reproducibility-manifest.js";
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const FIXED_TIMESTAMP = "2026-08-02T12:00:00.000Z";
+const FIXED_TOOL_VERSION = "pwnkit/0.1.0";
+
+function layerVerdicts(overrides: Partial<LayerVerdict>[] = []): LayerVerdict[] {
+  return [
+    {
+      layer: "oracle" as const,
+      verdict: "pass" as const,
+      reason: "PoC oracle confirms reachability",
+      durationMs: 42,
+      costUsd: 0,
+      ...(overrides[0] ?? {}),
+    },
+    {
+      layer: "skeptic" as const,
+      verdict: "pass" as const,
+      reason: "Skeptic could not refute",
+      durationMs: 120,
+      costUsd: 0,
+      ...(overrides[1] ?? {}),
+    },
+  ];
+}
+
+function pocSteps(): PocStep[] {
+  return [
+    {
+      id: "exploit",
+      kind: "exploit",
+      summary: "SQL injection in GET /api/reports",
+      action: {
+        type: "shell" as const,
+        cmd: "curl -X GET 'https://target.example/api/reports?date=2024-01-01' -H 'Authorization: Bearer secret-bearer-token'",
+      },
+    },
+  ];
+}
+
+function evidence(): Evidence {
+  return {
+    request: "GET /api/reports?date=2024-01-01 HTTP/1.1\nAuthorization: Bearer secret-bearer-token\nHost: target.example",
+    response: "HTTP/1.1 200 OK\nSet-Cookie: session=deadbeef\nContent-Type: application/json\n\n[{\"id\":1,\"ssn\":\"redacted\"}]",
+  };
+}
+
+function verifiedFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: "f-verify-001",
+    templateId: "tpl-sqli",
+    title: "SQL injection in /api/reports",
+    description: "Time-based SQL injection via the date parameter",
+    severity: "critical",
+    category: "sqli",
+    status: "verified",
+    evidence: evidence(),
+    pocSteps: pocSteps(),
+    pocExecution: {
+      findingId: "f-verify-001",
+      startedAt: "2026-08-02T11:00:00.000Z",
+      endedAt: "2026-08-02T11:00:05.000Z",
+      steps: [
+        {
+          stepId: "exploit",
+          kind: "passed" as const,
+          durationMs: 3200,
+          observedExit: 0,
+          observedStdout: "200 OK",
+        },
+      ],
+      overallVerdict: "exploit_still_works" as const,
+    },
+    layerVerdicts: layerVerdicts(),
+    ...overrides,
+  };
+}
+
+
+function verificationResult(
+  overrides: Partial<VerificationResult> = {},
+): VerificationResult {
+  return {
+    status: "reproduced",
+    mode: "deterministic_replay",
+    finding_id: "f-verify-001",
+    engine_version: "pwnkit/0.1.0",
+    started_at: FIXED_TIMESTAMP,
+    completed_at: FIXED_TIMESTAMP,
+    duration_ms: 1,
+    commands: [],
+    assertions: [],
+    evidence_artifacts: [],
+    engine_metadata: { os: "linux", arch: "x64", runner: "local" },
+    ...overrides,
+  };
+}
+
+const TARGET_IDENTIFIER = "https://target.example";
+
+// ── assembleReproducibilityManifest ─────────────────────────────────────────
+
+describe("assembleReproducibilityManifest", () => {
+  it("produces a deterministic manifest for a known timestamp + input", () => {
+    const manifest = assembleReproducibilityManifest(verifiedFinding(), {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+
+    expect(manifest.manifestVersion).toBe(1);
+    expect(manifest.generatedAt).toBe(FIXED_TIMESTAMP);
+    expect(manifest.findingId).toBe("f-verify-001");
+    expect(manifest.findingTitle).toBe("SQL injection in /api/reports");
+    expect(manifest.findingSeverity).toBe("critical");
+    expect(manifest.findingCategory).toBe("sqli");
+    expect(manifest.findingStatus).toBe("verified");
+    expect(manifest.targetIdentifier).toBe(TARGET_IDENTIFIER);
+    expect(manifest.toolVersion).toBe(FIXED_TOOL_VERSION);
+    expect(manifest.harnessRevision).toBeTruthy();
+    expect(typeof manifest.harnessRevision).toBe("string");
+    expect(manifest.harnessRevision!.length).toBe(64); // SHA-256 hex
+
+    // Environment fingerprint is populated from process (not stubbed — this
+    // test runs on the CI machine, so values are dynamic but present).
+    expect(manifest.environmentFingerprint.platform).toBeTruthy();
+    expect(manifest.environmentFingerprint.arch).toBeTruthy();
+    expect(manifest.environmentFingerprint.nodeVersion).toBeTruthy();
+
+    // Evidence hashes are deterministic: same input → same hex digest.
+    expect(manifest.evidenceHashes.requestHash).toBeTruthy();
+    expect(manifest.evidenceHashes.requestHash!.length).toBe(64);
+    expect(manifest.evidenceHashes.responseHash).toBeTruthy();
+    expect(manifest.evidenceHashes.responseHash!.length).toBe(64);
+
+    // Verification section populated from the fixture.
+    expect(manifest.verification.pocVerdict).toBe("exploit_still_works");
+    expect(manifest.verification.layerVerdictCount).toBe(2);
+    expect(manifest.verification.passedLayerCount).toBe(2);
+    expect(manifest.verification.verifiedAt).toBe("2026-08-02T11:00:00.000Z");
+    expect(manifest.verification.replayVerdict).toBeNull();
+  });
+
+
+  it("changes the harness revision when a nested PoC action changes", () => {
+    const original = assembleReproducibilityManifest(verifiedFinding(), {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+    });
+    const changed = assembleReproducibilityManifest(
+      verifiedFinding({
+        pocSteps: [
+          {
+            ...pocSteps()[0],
+            action: {
+              type: "shell",
+              cmd: "curl https://target.example/api/reports?date=2024-02-01",
+            },
+          },
+        ],
+      }),
+      { timestamp: FIXED_TIMESTAMP, toolVersion: FIXED_TOOL_VERSION },
+    );
+
+    expect(changed.harnessRevision).not.toBe(original.harnessRevision);
+  });
+
+
+  it("redacts secrets in an explicit target override", () => {
+    const manifest = assembleReproducibilityManifest(verifiedFinding(), {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: "https://target.example/?token=secret-bearer-token",
+    });
+
+    expect(manifest.targetIdentifier).not.toContain("secret-bearer-token");
+  });
+
+  it("produces the same manifest on repeated calls (determinism)", () => {
+    const finding = verifiedFinding();
+    const a = assembleReproducibilityManifest(finding, {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+    const b = assembleReproducibilityManifest(finding, {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+
+    expect(a).toEqual(b);
+  });
+
+  it("redacts evidence content before hashing", () => {
+    // The fixture has "Bearer secret-bearer-token" in the request evidence.
+    // The resulting request hash MUST be computed from the REDACTED content,
+    // not the raw content (otherwise the hash would leak secret existence).
+    const manifest = assembleReproducibilityManifest(verifiedFinding(), {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+
+    // The hash should be a 64-char hex string — can't reverse to secrets.
+    expect(manifest.evidenceHashes.requestHash).toMatch(/^[a-f0-9]{64}$/);
+
+    // Redactions applied should include both core sweeps plus the
+    // all-field redaction and userinfo stripping.
+    expect(manifest.redactionsApplied).toContain("redact-sensitive-headers");
+    expect(manifest.redactionsApplied).toContain("redact-pii");
+    expect(manifest.redactionsApplied).toContain("redact-all-text-fields");
+    expect(manifest.redactionsApplied).toContain("strip-url-userinfo");
+  });
+
+  it("does not include raw secret content in any manifest field", () => {
+    const manifest = assembleReproducibilityManifest(verifiedFinding(), {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+
+    // Check that raw strings are not present.
+    const json = JSON.stringify(manifest);
+    expect(json).not.toContain("secret-bearer-token");
+    expect(json).not.toContain("deadbeef");
+  });
+
+  it("refuses a non-verified finding with UnverifiedFindingError", () => {
+    const finding = verifiedFinding({ status: "discovered" });
+    expect(() =>
+      assembleReproducibilityManifest(finding, {
+        timestamp: FIXED_TIMESTAMP,
+        toolVersion: FIXED_TOOL_VERSION,
+      }),
+    ).toThrow(UnverifiedFindingError);
+  });
+
+  it("refuses a false-positive finding with UnverifiedFindingError", () => {
+    const finding = verifiedFinding({ status: "false-positive" });
+    expect(() =>
+      assembleReproducibilityManifest(finding, {
+        timestamp: FIXED_TIMESTAMP,
+        toolVersion: FIXED_TOOL_VERSION,
+      }),
+    ).toThrow(UnverifiedFindingError);
+  });
+
+  it("refuses a finding with no PoC execution and no layer verdicts", () => {
+    const finding = verifiedFinding({
+      pocExecution: undefined,
+      layerVerdicts: [],
+    });
+    expect(() =>
+      assembleReproducibilityManifest(finding, {
+        timestamp: FIXED_TIMESTAMP,
+        toolVersion: FIXED_TOOL_VERSION,
+      }),
+    ).toThrow(IncompleteEvidenceError);
+  });
+
+
+  it("refuses a verified finding without successful impact evidence", () => {
+    const finding = verifiedFinding({
+      pocExecution: {
+        ...verifiedFinding().pocExecution!,
+        overallVerdict: "could_not_run",
+      },
+      layerVerdicts: layerVerdicts([
+        { verdict: "error" },
+        { verdict: "error" },
+      ]),
+    });
+
+    expect(() =>
+      assembleReproducibilityManifest(finding, {
+        timestamp: FIXED_TIMESTAMP,
+        toolVersion: FIXED_TOOL_VERSION,
+      }),
+    ).toThrow(IncompleteEvidenceError);
+  });
+
+
+  it("sets harnessRevision to null when no pocSteps exist", () => {
+    const finding = verifiedFinding({ pocSteps: undefined });
+    const manifest = assembleReproducibilityManifest(finding, {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+    expect(manifest.harnessRevision).toBeNull();
+  });
+
+  it("includes modelConfig when provided", () => {
+    const manifest = assembleReproducibilityManifest(verifiedFinding(), {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+      modelConfig: "anthropic/claude-sonnet-4",
+    });
+    expect(manifest.modelConfig).toBe("anthropic/claude-sonnet-4");
+  });
+
+  it("sets modelConfig to null when omitted", () => {
+    const manifest = assembleReproducibilityManifest(verifiedFinding(), {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+    expect(manifest.modelConfig).toBeNull();
+  });
+
+  it("preserves the canonical replay status when present", () => {
+    const finding = verifiedFinding({
+      verification_result: verificationResult(),
+    });
+    const manifest = assembleReproducibilityManifest(finding, {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+    expect(manifest.verification.replayVerdict).toBe("reproduced");
+  });
+
+  it("sets replayVerdict to null when verification_result is absent", () => {
+    // verification_result is undefined
+    const manifest = assembleReproducibilityManifest(verifiedFinding(), {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+    expect(manifest.verification.replayVerdict).toBeNull();
+  });
+
+  it("accepts a finding with OAST-confirmed replay when PoC execution is absent", () => {
+    // The gate allows OAST-confirmed replays even without a successful
+    // behavioural PoC execution. pocVerdict should be null (no exec ran),
+    // replayVerdict should come from the verification_result.
+    const finding = verifiedFinding({
+      pocExecution: undefined,
+      verification_result: verificationResult({
+        status: "reproduced",
+        oast_confirmed: true,
+      }),
+    });
+    const manifest = assembleReproducibilityManifest(finding, {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+
+    expect(manifest.verification.pocVerdict).toBeNull();
+    expect(manifest.verification.replayVerdict).toBe("reproduced");
+    expect(manifest.redactionsApplied).toContain("replay-verified-impact");
+    expect(manifest.redactionsApplied).not.toContain("poc-verified-impact");
+  });
+
+  it("sets evidence hashes to null when evidence request or response is absent", () => {
+    const withoutEvidence = verifiedFinding({ evidence: {} });
+    const manifest = assembleReproducibilityManifest(withoutEvidence, {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+
+    expect(manifest.evidenceHashes.requestHash).toBeNull();
+    expect(manifest.evidenceHashes.responseHash).toBeNull();
+  });
+
+  it("accepts a finding with OAST-confirmed replay but absent status field", () => {
+    // oast_confirmed can be true even when the replay status is absent/null.
+    const finding = verifiedFinding({
+      pocExecution: undefined,
+      verification_result: verificationResult({
+        status: null as unknown as string,
+        oast_confirmed: true,
+      }),
+    });
+    const manifest = assembleReproducibilityManifest(finding, {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+
+    expect(manifest.verification.pocVerdict).toBeNull();
+    expect(manifest.redactionsApplied).toContain("replay-verified-impact");
+  });
+
+  // ── Injection and sanitization resistance ────────────────────────────────
+
+  it("strips URL userinfo from target identifier", () => {
+    const manifest = assembleReproducibilityManifest(verifiedFinding(), {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: "https://admin:supersecret@internal.corp.example/api",
+    });
+    expect(manifest.targetIdentifier).not.toContain("admin");
+    expect(manifest.targetIdentifier).not.toContain("supersecret");
+    expect(manifest.targetIdentifier).toContain("[REDACTED-USER]");
+  });
+
+  it("redacts client_secret and password query parameters", () => {
+    const manifest = assembleReproducibilityManifest(verifiedFinding(), {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier:
+        "https://api.example.com/token?client_id=app&client_secret=sk-secret&password=hunter2",
+    });
+    expect(manifest.targetIdentifier).not.toContain("sk-secret");
+    expect(manifest.targetIdentifier).not.toContain("hunter2");
+    expect(manifest.targetIdentifier).toContain("[REDACTED]");
+  });
+
+  it("redacts externally controlled finding metadata fields", () => {
+    // The finding ID, severity, category, and status all come from the
+    // Finding which is under external control — they must be redacted.
+    const finding = verifiedFinding({
+      id: "f-email@evil.com-attack",
+      severity: "critical-client_secret=sk-leaked",
+      category: "sqli?password=mysecretpass",
+      status: "confirmed",
+    });
+    const manifest = assembleReproducibilityManifest(finding, {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+    const rendered = renderReproducibilityManifest(manifest);
+    // The email-like ID should be PII-redacted.
+    expect(manifest.findingId).not.toContain("@evil.com");
+    // A secret-like severity value should be sanitized.
+    expect(manifest.findingSeverity).not.toContain("sk-leaked");
+    // A key=value in category should be sanitized.
+    expect(manifest.findingCategory).not.toContain("mysecretpass");
+    // The rendered output should also be clean.
+    expect(rendered).not.toContain("@evil.com");
+    expect(rendered).not.toContain("sk-leaked");
+    expect(rendered).not.toContain("mysecretpass");
+  });
+
+  it("redacts externally controlled verification field strings", () => {
+    // PocVerdict, replayVerdict, and verifiedAt all come from finding data
+    // and must be redacted before appearing in the manifest.
+    // We inject secrets into pocExecution.startedAt (becomes verifiedAt)
+    // and verification_result.status (becomes replayVerdict) while keeping
+    // the gate-passing conditions intact.
+    const finding = verifiedFinding({
+      pocExecution: {
+        findingId: "f-001",
+        startedAt: "2026-08-02T11:00:00.000Z?token=mysecrettoken",
+        endedAt: "2026-08-02T11:00:05.000Z",
+        steps: [
+          {
+            stepId: "exploit",
+            kind: "passed" as const,
+            durationMs: 3200,
+            observedExit: 0,
+            observedStdout: "200 OK",
+          },
+        ],
+        overallVerdict: "exploit_still_works" as const,
+      },
+      verification_result: {
+        status: "reproduced",
+        oast_confirmed: false,
+        mode: "deterministic_replay",
+        finding_id: "f-001",
+        engine_version: "pwnkit/0.1.0",
+        started_at: "2026-08-02T11:00:00.000Z",
+        completed_at: "2026-08-02T11:00:05.000Z?client_secret=sk-xxx",
+        duration_ms: 1,
+        commands: [],
+        assertions: [],
+        evidence_artifacts: [],
+        engine_metadata: { os: "linux", arch: "x64", runner: "local" },
+      },
+    });
+    const manifest = assembleReproducibilityManifest(finding, {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+
+    // pocVerdict = "exploit_still_works" — should not have been modified.
+    expect(manifest.verification.pocVerdict).toBe("exploit_still_works");
+    // verifiedAt comes from startedAt which had ?token=... appended.
+    expect(manifest.verification.verifiedAt).not.toContain("mysecrettoken");
+    // verifiedAt also from completed_at with client_secret
+    expect(manifest.verification.verifiedAt).not.toContain("sk-xxx");
+    // replayVerdict = "reproduced" — should pass through clean.
+    expect(manifest.verification.replayVerdict).toBe("reproduced");
+  });
+
+  it("redacts externally controlled tool-version and timestamp strings", () => {
+    const manifest = assembleReproducibilityManifest(verifiedFinding(), {
+      timestamp: "2026-08-02T12:00:00.000Z?token=injected",
+      toolVersion: "pwnkit/0.1.0?password=pass123",
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+    expect(manifest.generatedAt).not.toContain("injected");
+    expect(manifest.toolVersion).not.toContain("pass123");
+  });
+
+  it("end-to-end: rendered output contains no raw secrets from any field", () => {
+    const finding = verifiedFinding({
+      id: "f-ssn-leak",
+      title: "User data leak?token=myapitoken",
+      severity: "critical",
+      category: "sqli?password=hunter2",
+      evidence: {
+        request:
+          "GET /api/users?password=hunter2 HTTP/1.1\nAuthorization: Bearer my-jwt-token\nCookie: session=abc123",
+        response:
+          "HTTP/1.1 200 OK\nSet-Cookie: session=deadbeef\nContent-Type: application/json\n\n{\"ssn\":\"123-45-6789\"}",
+      },
+    });
+    const manifest = assembleReproducibilityManifest(finding, {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: "https://admin:secret@api.example.com/users?token=xxx",
+    });
+    const rendered = renderReproducibilityManifest(manifest);
+
+    // Raw secrets from different field sources are redacted.
+    expect(rendered).not.toContain("hunter2");
+    expect(rendered).not.toContain("my-jwt-token");
+    expect(rendered).not.toContain("123-45-6789");
+    expect(rendered).not.toContain("abc123");
+    expect(rendered).not.toContain("admin");
+    expect(rendered).not.toContain("myapitoken");
+    // Evidence section shows only hashes, not raw content.
+    expect(rendered).toMatch(/Request \(SHA-256\)\s+[a-f0-9]{64}/);
+    expect(rendered).toMatch(/Response \(SHA-256\)\s+[a-f0-9]{64}/);
+  });
+});
+
+// ── renderReproducibilityManifest ───────────────────────────────────────────
+
+describe("renderReproducibilityManifest", () => {
+  it("includes all top-level sections", () => {
+    const manifest = assembleReproducibilityManifest(verifiedFinding(), {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+    const text = renderReproducibilityManifest(manifest);
+
+    expect(text).toContain("REPRODUCIBILITY MANIFEST");
+    expect(text).toContain("Target");
+    expect(text).toContain("Environment");
+    expect(text).toContain("Evidence");
+    expect(text).toContain("Verification");
+    expect(text).toContain("Redactions applied");
+    expect(text).toContain("FOR HUMAN REVIEW ONLY");
+  });
+
+  it("includes specific field values in the output", () => {
+    const manifest = assembleReproducibilityManifest(verifiedFinding(), {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+    const text = renderReproducibilityManifest(manifest);
+
+    expect(text).toContain(FIXED_TIMESTAMP);
+    expect(text).toContain("f-verify-001");
+    expect(text).toContain("SQL injection in /api/reports");
+    expect(text).toContain(FIXED_TOOL_VERSION);
+    expect(text).toContain(TARGET_IDENTIFIER);
+  });
+
+  it("never leaks secrets into the rendered output", () => {
+    const manifest = assembleReproducibilityManifest(verifiedFinding(), {
+      timestamp: FIXED_TIMESTAMP,
+      toolVersion: FIXED_TOOL_VERSION,
+      targetIdentifier: TARGET_IDENTIFIER,
+    });
+    const text = renderReproducibilityManifest(manifest);
+
+    expect(text).not.toContain("secret-bearer-token");
+    expect(text).not.toContain("deadbeef");
+  });
+});

--- a/packages/core/src/disclose/reproducibility-manifest.ts
+++ b/packages/core/src/disclose/reproducibility-manifest.ts
@@ -1,0 +1,488 @@
+/**
+ * #151 — Reproducibility manifest for verified findings.
+ *
+ * A deterministic, redacted, locally-assembled snapshot of the full
+ * reproducibility context: scope, target, tool revision, model/provider
+ * configuration, environment fingerprint, evidence hashes, verification
+ * status, and generation time. Reuses `redactSensitiveHeaders` and
+ * `redactPii` from the existing disclosure pipeline so the same secret
+ * and PII sweep covers the manifest.
+ *
+ * Designed to be surfaced for HUMAN INSPECTION via `pwnkit disclose review`
+ * BEFORE any disclosure artifact is drafted. The manifest itself never sends
+ * or publishes anything.
+ *
+ * INVARIANTS:
+ *   - Deterministic for a supplied timestamp + input.
+ *   - Refuses incomplete or non-verified-PoV evidence.
+ *   - Redacts credentials, cookies, auth headers, tokens, email/PII, and
+ *     raw sensitive request/response content by default.
+ *   - Evidence is hashed AFTER redaction so the hash is safe to publish.
+ */
+
+import { createHash } from "node:crypto";
+import { redactSensitiveHeaders } from "./template.js";
+import { redactPii } from "./writeup.js";
+import type { Finding, VerificationResult } from "@pwnkit/shared";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+/**
+ * The deterministic, redacted reproducibility manifest for one verified
+ * finding. Every string field is already redacted before it reaches this
+ * type — the assembler guarantees that.
+ */
+export interface ReproducibilityManifest {
+  /** Manifest schema version (bump on breaking shape changes). */
+  manifestVersion: 1;
+
+  /** ISO-8601 generation timestamp (deterministic via options). */
+  generatedAt: string;
+
+  /** The finding identifier this manifest was assembled from. */
+  findingId: string;
+  /** Finding title (redacted). */
+  findingTitle: string;
+  /** Finding severity. */
+  findingSeverity: string;
+  /** Finding category. */
+  findingCategory: string;
+
+  /** Status of the finding at manifest generation time. */
+  findingStatus: string;
+
+  /** Target identifier: URL, package, or repo (PII-redacted). */
+  targetIdentifier: string;
+
+  /**
+   * Tool / pwnkit version manifest was assembled under.
+   * Falls back to `"unknown"` when the version is not embedded at build time.
+   */
+  toolVersion: string;
+
+  /**
+   * Deterministic hash of the finding's structured PoC step graph, if
+   * present. SHA-256 of the JSON-stringified `pocSteps` array (after
+   * redaction of each step's command/body content).
+   */
+  harnessRevision: string | null;
+
+  /**
+   * Provider and model name, if available at assembly time.
+   * Redacted if it contains user-identifying information.
+   */
+  modelConfig: string | null;
+
+  /**
+   * Environment fingerprint: operating system, architecture, and
+   * Node.js runtime version.
+   */
+  environmentFingerprint: {
+    /** `process.platform` value, e.g. `"darwin"`, `"linux"`, `"win32"`. */
+    platform: string;
+    /** `process.arch` value, e.g. `"arm64"`, `"x64"`. */
+    arch: string;
+    /** Node.js version string, e.g. `"v22.0.0"`. */
+    nodeVersion: string;
+  };
+
+  /**
+   * SHA-256 hashes of the finding's evidence request and response
+   * content, computed AFTER `redactSensitiveHeaders` has been applied.
+   * This ensures the hashes are safe to include in any downstream
+   * artifact without leaking secrets.
+   */
+  evidenceHashes: {
+    requestHash: string | null;
+    responseHash: string | null;
+  };
+
+  /**
+   * Aggregate verification status drawn from the finding's PoC execution
+   * report and layer verdicts.
+   */
+  verification: {
+    /** The overall PoC verdict, if a behavioural re-verify ran. */
+    pocVerdict: string | null;
+    /** Number of triage layer verdicts present. */
+    layerVerdictCount: number;
+    /**
+     * Number of passing layer verdicts. A verified finding should have
+     * at least one pass to be considered complete.
+     */
+    passedLayerCount: number;
+    /** The last deterministic-replay verification result, if any. */
+    replayVerdict: string | null;
+    /** ISO-8601 timestamp of the PoC execution, if available. */
+    verifiedAt: string | null;
+  };
+
+  /** Which redaction sweeps were applied during assembly. */
+  redactionsApplied: string[];
+}
+
+export interface ManifestOptions {
+  /**
+   * Override the generation timestamp (ISO-8601 string). Used by tests
+   * to assert deterministic output. Defaults to `new Date().toISOString()`.
+   */
+  timestamp?: string;
+  /**
+   * Override the tool version string. Used by tests and build-embedded
+   * version stamps. Defaults to trying `process.env.PWNKIT_VERSION` or
+   * read from the package.json at build time, falling back to `"unknown"`.
+   */
+  toolVersion?: string;
+  /**
+   * Model/provider config string. e.g. `"anthropic/claude-sonnet-4"`,
+   * `"openai/gpt-4o"`. Redacted if it contains PII.
+   */
+  modelConfig?: string;
+  /**
+   * Override the target identifier. When omitted, extracted from the
+   * finding's evidence request URL if available.
+   */
+  targetIdentifier?: string;
+}
+
+// ── Errors ──────────────────────────────────────────────────────────────────
+
+export class UnverifiedFindingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnverifiedFindingError";
+  }
+}
+
+export class IncompleteEvidenceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IncompleteEvidenceError";
+  }
+}
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+/** The current manifest schema version. Bump on breaking shape changes. */
+export const MANIFEST_VERSION = 1 as const;
+
+/**
+ * Hash algorithm used for evidence digests. Chosen for availability,
+ * speed, and collision resistance adequate for reproducibility assertions.
+ */
+const HASH_ALGORITHM = "sha256";
+
+/** Finding statuses that clear the verified gate. */
+const VERIFIED_STATUSES: Record<string, true> = {
+  verified: true,
+  confirmed: true,
+};
+
+
+/**
+ * Strip RFC 3986 userinfo (user:password@host) from URLs before the value
+ * enters a manifest or digest. Replaces the entire userinfo with [REDACTED]
+ * while preserving the scheme and host.
+ */
+const SENSITIVE_USERINFO = /([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^@\n]+@/gi;
+
+/**
+ * Sensitive URL parameter values and credentials that header-only redaction
+ * does not reach. Matches common OAuth, API, and authentication parameter
+ * names.
+ */
+const SENSITIVE_QUERY_VALUE = /([?&](?:access_token|api[_-]?key|authorization|auth|cookie|session|token|bearer|jwt|refresh_token|client_secret|client_id|password|passwd|secret)=)[^&#\s]*/gi;
+
+/**
+ * Standalone credential key=value pattern for free-form text fields that
+ * are not URL query strings (e.g. severity, category, generatedAt, tool
+ * version). Catches cases where an externally controlled string contains
+ * something like "critical-client_secret=sk-leaked" without a preceding
+ * ? or &. Uses word-boundary lookahead to avoid false matches on
+ * unrelated hyphenated words.
+ */
+const STANDALONE_CREDENTIAL = /(^|[\s,;:.-])((?:access_token|api[_-]?key|authorization|auth|cookie|session|token|bearer|jwt|refresh_token|client_secret|client_id|password|passwd|secret)=)[^\s,;:)\]"'`]*(?![\w-])/gi;
+
+
+/** Apply every redaction needed before a value enters a manifest or digest. */
+function redactManifestValue(value: string): string {
+  return redactPii(
+    redactSensitiveHeaders(value)
+      .replace(SENSITIVE_USERINFO, "$1[REDACTED-USER]@")
+      .replace(SENSITIVE_QUERY_VALUE, "$1[REDACTED]")
+      .replace(STANDALONE_CREDENTIAL, "$1$2[REDACTED]"),
+  );
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Safely redact and hash a string value. Returns null when the input is
+ * null, undefined, or empty.
+ */
+function redactAndHash(value: string | null | undefined): string | null {
+  if (!value) return null;
+  return createHash(HASH_ALGORITHM)
+    .update(redactManifestValue(value), "utf8")
+    .digest("hex");
+}
+
+/**
+ * Produce a stable recursive JSON representation. A top-level replacer array
+ * would silently omit nested fields, which would make materially different PoC
+ * graphs share a harness revision.
+ */
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .filter((key) => record[key] !== undefined)
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(",")}}`;
+}
+
+
+/**
+ * Collect the non-sensitive environment fingerprint that is safe to
+ * include in a reproducibility manifest.
+ */
+function collectEnvironmentFingerprint(): ReproducibilityManifest["environmentFingerprint"] {
+  return {
+    platform: process.platform,
+    arch: process.arch,
+    nodeVersion: process.version,
+  };
+}
+
+/**
+ * Extract a target identifier from a finding, falling back to "unknown".
+ * The result is PII-redacted.
+ */
+function extractTarget(finding: Finding): string {
+  const url = finding.evidence?.request?.match(/^(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+(\S+)/)?.[1]
+    ?? finding.evidence?.request?.match(/^\S+/)?.[0];
+  if (url) return redactManifestValue(url);
+  if (finding.title) return redactManifestValue(finding.title);
+  return "unknown";
+}
+
+/**
+ * Compute the PoC step graph revision hash. Redacts each step's
+ * command/body content before hashing so the harness fingerprint is
+ * itself safe to share.
+ */
+function computeHarnessRevision(finding: Finding): string | null {
+  if (!finding.pocSteps || finding.pocSteps.length === 0) return null;
+
+  const redactedSteps = finding.pocSteps.map((step) => {
+    const action = step.action ? { ...step.action } : step.action;
+    if (action && "cmd" in action && typeof action.cmd === "string") {
+      (action as Record<string, unknown>).cmd = redactManifestValue(action.cmd);
+    }
+    if (action && "body" in action && typeof action.body === "string") {
+      (action as Record<string, unknown>).body = redactManifestValue(action.body);
+    }
+    return { ...step, action };
+  });
+
+  return createHash(HASH_ALGORITHM)
+    .update(canonicalJson(redactedSteps), "utf8")
+    .digest("hex");
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Assemble a deterministic, redacted reproducibility manifest from a
+ * verified finding.
+ *
+ * Gates:
+ *   - `UnverifiedFindingError` when the finding's status is not
+ *     `verified` or `confirmed`.
+ *   - `IncompleteEvidenceError` when the finding has no PoC execution
+ *     report AND no layer verdicts — i.e. the evidence is incomplete.
+ *
+ * @param finding — The verified finding to manifest.
+ * @param opts — Optional configuration overrides for deterministic output.
+ * @returns A redacted ReproducibilityManifest.
+ */
+export function assembleReproducibilityManifest(
+  finding: Finding,
+  opts: ManifestOptions = {},
+): ReproducibilityManifest {
+  const redactionsApplied: string[] = [];
+
+  // ── Gate: verified status ────────────────────────────────────────────
+  if (!VERIFIED_STATUSES[finding.status]) {
+    throw new UnverifiedFindingError(
+      `Cannot assemble reproducibility manifest for finding ${finding.id}: status is "${finding.status}", expected "verified" or "confirmed".`,
+    );
+  }
+  redactionsApplied.push("verified-status-gate");
+
+  // ── Gate: successful verified PoV/impact ────────────────────────────
+  // A layer verdict is triage evidence, not a successful PoV. This manifest
+  // needs either behavioural proof or a canonical deterministic replay receipt.
+  const pocExec = finding.pocExecution as
+    | { overallVerdict?: string; startedAt?: string }
+    | undefined;
+  const layerVerdicts = finding.layerVerdicts ?? [];
+  const replayResult = finding.verification_result as VerificationResult | undefined;
+  const pocSuccessful = pocExec?.overallVerdict === "exploit_still_works";
+  const replaySuccessful =
+    replayResult?.status === "reproduced" || replayResult?.oast_confirmed === true;
+
+  if (!pocSuccessful && !replaySuccessful) {
+    throw new IncompleteEvidenceError(
+      `Cannot assemble reproducibility manifest for finding ${finding.id}: no successful verified PoV. ` +
+        `PoC verdict was ${pocExec?.overallVerdict ?? "absent"} and replay status was ` +
+        `${replayResult?.status ?? "absent"}. A reproduced PoC or verified replay is required.`,
+    );
+  }
+
+  const pocVerdict = pocExec?.overallVerdict ?? null;
+  const passedLayerCount = layerVerdicts.filter(
+    (verdict) => verdict.verdict === "pass",
+  ).length;
+  const verifiedAt = pocExec?.startedAt ?? replayResult?.completed_at ?? null;
+  const replayVerdict = replayResult?.status ?? null;
+
+  if (pocSuccessful) redactionsApplied.push("poc-verified-impact");
+  if (replaySuccessful) redactionsApplied.push("replay-verified-impact");
+  const target = opts.targetIdentifier
+    ? redactManifestValue(opts.targetIdentifier)
+    : extractTarget(finding);
+  const modelConfig = opts.modelConfig
+    ? redactManifestValue(opts.modelConfig)
+    : null;
+  const toolVersion = opts.toolVersion ?? process.env.PWNKIT_VERSION ?? "unknown";
+  const timestamp = opts.timestamp ?? new Date().toISOString();
+
+  // Redact the finding title through the full sanitization pipeline.
+  const sanitizedTitle = redactManifestValue(finding.title);
+
+  // Compute evidence hashes after redaction.
+  const evidenceReq = finding.evidence?.request ?? null;
+  const evidenceRes = finding.evidence?.response ?? null;
+  const evidenceHashes = {
+    requestHash: redactAndHash(evidenceReq),
+    responseHash: redactAndHash(evidenceRes),
+  };
+
+  // Compute harness revision from redacted PoC steps.
+  const harnessRevision = computeHarnessRevision(finding);
+
+
+  // Redact EVERY externally-controlled string before it enters the manifest.
+  // This covers finding metadata, option-derived values, verification
+  // timestamps and verdicts — not just the target identifier and title.
+  const sanitizedGeneratedAt = redactManifestValue(timestamp);
+  const sanitizedFindingId = redactManifestValue(finding.id);
+  const sanitizedSeverity = redactManifestValue(finding.severity);
+  const sanitizedCategory = redactManifestValue(finding.category);
+  const sanitizedStatus = redactManifestValue(finding.status);
+  const sanitizedToolVersion = redactManifestValue(toolVersion);
+  const sanitizedPocVerdict = pocVerdict ? redactManifestValue(pocVerdict) : null;
+  const sanitizedReplayVerdict = replayVerdict ? redactManifestValue(replayVerdict) : null;
+  const sanitizedVerifiedAt = verifiedAt ? redactManifestValue(verifiedAt) : null;
+
+  // Collect which sweeps ran.
+  redactionsApplied.push("redact-sensitive-headers");
+  redactionsApplied.push("redact-pii");
+  redactionsApplied.push("redact-all-text-fields");
+  redactionsApplied.push("strip-url-userinfo");
+
+  return {
+    manifestVersion: MANIFEST_VERSION,
+    generatedAt: sanitizedGeneratedAt,
+    findingId: sanitizedFindingId,
+    findingTitle: sanitizedTitle,
+    findingSeverity: sanitizedSeverity,
+    findingCategory: sanitizedCategory,
+    findingStatus: sanitizedStatus,
+    targetIdentifier: target,
+    toolVersion: sanitizedToolVersion,
+    harnessRevision,
+    modelConfig,
+    environmentFingerprint: collectEnvironmentFingerprint(),
+    evidenceHashes,
+    verification: {
+      pocVerdict: sanitizedPocVerdict,
+      layerVerdictCount: layerVerdicts.length,
+      passedLayerCount,
+      replayVerdict: sanitizedReplayVerdict,
+      verifiedAt: sanitizedVerifiedAt,
+    },
+    redactionsApplied,
+  };
+}
+
+/**
+ * Render a ReproducibilityManifest as a human-readable text block for
+ * CLI display or local review. Returns a string — writes nothing.
+ *
+ * The output is already redacted by the assembler; this function only
+ * formats it for terminal consumption.
+ */
+export function renderReproducibilityManifest(manifest: ReproducibilityManifest): string {
+  const lines: string[] = [];
+  const add = (key: string, val: unknown) => {
+    lines.push(`  ${key.padEnd(28)} ${val ?? "—"}`);
+  };
+
+  lines.push("─".repeat(72));
+  lines.push("  REPRODUCIBILITY MANIFEST  (v" + manifest.manifestVersion + ")");
+  lines.push("─".repeat(72));
+  lines.push("");
+  add("Generated", manifest.generatedAt);
+  add("Finding ID", manifest.findingId);
+  add("Title", manifest.findingTitle);
+  add("Severity", manifest.findingSeverity);
+  add("Category", manifest.findingCategory);
+  add("Status", manifest.findingStatus);
+  lines.push("");
+
+  lines.push("  Target");
+  lines.push("  " + "─".repeat(66));
+  add("Identifier", manifest.targetIdentifier);
+  lines.push("");
+
+  lines.push("  Environment");
+  lines.push("  " + "─".repeat(66));
+  add("Tool version", manifest.toolVersion);
+  add("Platform", manifest.environmentFingerprint.platform);
+  add("Architecture", manifest.environmentFingerprint.arch);
+  add("Node.js", manifest.environmentFingerprint.nodeVersion);
+  add("Model config", manifest.modelConfig ?? "—");
+  lines.push("");
+
+  lines.push("  Evidence");
+  lines.push("  " + "─".repeat(66));
+  add("Request (SHA-256)", manifest.evidenceHashes.requestHash ?? "—");
+  add("Response (SHA-256)", manifest.evidenceHashes.responseHash ?? "—");
+  add("Harness revision", manifest.harnessRevision ?? "—");
+  lines.push("");
+
+  lines.push("  Verification");
+  lines.push("  " + "─".repeat(66));
+  add("PoC verdict", manifest.verification.pocVerdict ?? "—");
+  add("Layer verdicts", `${manifest.verification.passedLayerCount}/${manifest.verification.layerVerdictCount} pass`);
+  add("Replay verdict", manifest.verification.replayVerdict ?? "—");
+  add("Verified at", manifest.verification.verifiedAt ?? "—");
+  lines.push("");
+
+  lines.push("  Redactions applied");
+  lines.push("  " + "─".repeat(66));
+  for (const r of manifest.redactionsApplied) {
+    lines.push(`    • ${r}`);
+  }
+  lines.push("");
+  lines.push("─".repeat(72));
+  lines.push("  MANIFEST — FOR HUMAN REVIEW ONLY. NOT A DISCLOSURE ARTIFACT.");
+  lines.push("─".repeat(72));
+
+  return lines.join("\n");
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1958,6 +1958,17 @@ export * from "./adgraph/index.js";
 export * from "./identity/index.js";
 export * from "./attack/index.js";
 
+// Local, redacted reproducibility manifests for verified findings.
+export {
+  assembleReproducibilityManifest,
+  renderReproducibilityManifest,
+  UnverifiedFindingError,
+  IncompleteEvidenceError,
+} from "./disclose/reproducibility-manifest.js";
+export type {
+  ReproducibilityManifest,
+  ManifestOptions,
+} from "./disclose/reproducibility-manifest.js";
 // file-review — deepsec-pattern whole-repo review harness (scan → coverage
 // gate → batched AI investigation with refusal audit/field repair →
 // static revalidation), resumable with cost/duration caps.


### PR DESCRIPTION
## Scope
Ports the redacted local reproducibility-manifest flow behind `disclose review`. It rejects unverified findings and incomplete evidence, and never sends or publishes a disclosure.

## Verification
- pnpm build
- pnpm lint
- pnpm test:public
- Foxguard diff: zero new high/critical findings
- Secret scan findings are fixture-only