### PR TITLE
feat(public): port windowed file reads

### DIFF
--- a/packages/core/src/agent/tools.test.ts
+++ b/packages/core/src/agent/tools.test.ts
@@ -43,6 +43,15 @@ describe("TOOL_DEFINITIONS", () => {
       expect(TOOL_DEFINITIONS[name].description).toBeTruthy();
     }
   });
+
+  it("advertises a 1-based read_file offset", () => {
+    const def = TOOL_DEFINITIONS.read_file;
+    expect(def.parameters.offset).toBeDefined();
+    expect(def.parameters.offset.type).toBe("number");
+    expect(def.parameters.offset.description).toContain("1-based");
+    expect(def.required).toEqual(["path"]);
+    expect(def.description).not.toContain("Returns numbered lines");
+  });
 });
 
 // ── Role-based Tool Selection ──
@@ -1245,6 +1254,104 @@ describe("ToolExecutor", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("scoped local directory");
+  });
+
+  describe("read_file windowed reads", () => {
+    let tmp: string;
+    let scopedExecutor: ToolExecutor;
+    const BIG_FILE = Array.from({ length: 1200 }, (_, i) => `line ${i + 1}`).join("\n");
+
+    beforeEach(() => {
+      tmp = mkdtempSync(join(tmpdir(), "pwnkit-read-file-exec-"));
+      writeFileSync(join(tmp, "big.c"), BIG_FILE);
+      scopedExecutor = new ToolExecutor({ ...ctx, scopePath: tmp }, null);
+    });
+
+    afterEach(() => {
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it("returns the first 500 lines when no offset is given", async () => {
+      const result = await scopedExecutor.execute({
+        name: "read_file",
+        arguments: { path: "big.c" },
+      });
+
+      expect(result.success).toBe(true);
+      const out = result.output as {
+        content: string;
+        totalLines: number;
+        truncated: boolean;
+        startLine: number;
+        endLine: number;
+        nextOffset?: number;
+      };
+      expect(out.totalLines).toBe(1200);
+      expect(out.truncated).toBe(true);
+      expect(out.startLine).toBe(1);
+      expect(out.endLine).toBe(500);
+      expect(out.nextOffset).toBe(501);
+      expect(out.content.startsWith("line 1\nline 2\n")).toBe(true);
+    });
+
+    it("reads a window in the middle of the file", async () => {
+      const result = await scopedExecutor.execute({
+        name: "read_file",
+        arguments: { path: "big.c", offset: 800, max_lines: 3 },
+      });
+
+      expect(result.success).toBe(true);
+      const out = result.output as { content: string; startLine: number; endLine: number };
+      expect(out.startLine).toBe(800);
+      expect(out.endLine).toBe(802);
+      expect(out.content.split("\n").slice(0, 3)).toEqual(["line 800", "line 801", "line 802"]);
+    });
+
+    it("signals truncation with the next offset", async () => {
+      const result = await scopedExecutor.execute({
+        name: "read_file",
+        arguments: { path: "big.c", offset: 800, max_lines: 3 },
+      });
+
+      expect(result.success).toBe(true);
+      const out = result.output as { content: string };
+      expect(out.content).toContain("[pwnkit:read_file] TRUNCATED");
+      expect(out.content).toContain("showed lines 800-802 of 1200");
+      expect(out.content).toContain("offset=803");
+    });
+
+    it("returns an empty window for an offset past EOF", async () => {
+      const result = await scopedExecutor.execute({
+        name: "read_file",
+        arguments: { path: "big.c", offset: 99999 },
+      });
+
+      expect(result.success).toBe(true);
+      const out = result.output as { content: string; totalLines: number; truncated: boolean };
+      expect(out.totalLines).toBe(1200);
+      expect(out.truncated).toBe(false);
+      expect(out.content).toContain("past the end of this file");
+    });
+
+    it("rejects a 0-based offset", async () => {
+      const result = await scopedExecutor.execute({
+        name: "read_file",
+        arguments: { path: "big.c", offset: 0 },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("1-based");
+    });
+
+    it("enforces the scope guard before reading", async () => {
+      const result = await scopedExecutor.execute({
+        name: "read_file",
+        arguments: { path: "../../../etc/passwd", offset: 1 },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("escapes the allowed scope");
+    });
   });
 
   it("run_command fails without scopePath", async () => {

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -141,6 +141,7 @@ import {
   executeIntelSearchTargetHistory,
 } from "./tools/intel.js";
 import { resolveScopedPath } from "./tools/scope-path.js";
+import { windowFileContent } from "./tools/read-file-window.js";
 
 // ── Tool registry (pwnkit#611) ──
 // The per-tool ToolDefinition objects now live in per-domain modules under
@@ -4633,22 +4634,26 @@ export class ToolExecutor {
     }
 
     const requestedPath = args.path as string;
-    // `max_lines` is honoured when the CALLER asks for it. There is no implicit
-    // 500-line head cap any more: a head-only line slice silently hid the end of
-    // every long file, and the shared tool-output policy already bounds size
-    // while keeping both ends.
-    const maxLines = typeof args.max_lines === "number" ? args.max_lines : undefined;
     const path = resolveScopedPath(this.ctx.scopePath, requestedPath);
-
-    const content = readFileSync(path, "utf-8");
-    const lines = content.split("\n");
-    const lineLimited = maxLines !== undefined && lines.length > maxLines;
-    const selected = lineLimited ? lines.slice(0, maxLines).join("\n") : content;
-    const output = formatTruncated(selected);
+    const raw = readFileSync(path, "utf-8");
+    const window = windowFileContent(raw, {
+      offset: args.offset,
+      maxLines: args.max_lines,
+    });
+    if (!window.ok) {
+      return { success: false, output: null, error: window.error };
+    }
 
     return {
       success: true,
-      output: { content: output, totalLines: lines.length, truncated: lineLimited || output !== selected },
+      output: {
+        content: window.content,
+        totalLines: window.totalLines,
+        truncated: window.truncated,
+        startLine: window.startLine,
+        endLine: window.endLine,
+        ...(window.nextOffset !== undefined ? { nextOffset: window.nextOffset } : {}),
+      },
     };
   }
 

--- a/packages/core/src/agent/tools/read-file-window.test.ts
+++ b/packages/core/src/agent/tools/read-file-window.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import {
+  windowFileContent,
+  READ_FILE_DEFAULT_MAX_LINES,
+  READ_FILE_NOTE_PREFIX,
+} from "./read-file-window.js";
+
+/** A file whose Nth line literally reads "line N", so windows are self-checking. */
+function numberedFile(lineCount: number): string {
+  return Array.from({ length: lineCount }, (_, i) => `line ${i + 1}`).join("\n");
+}
+
+/** The content minus any appended `[pwnkit:read_file]` status lines. */
+function bodyLines(content: string): string[] {
+  return content.split("\n").filter((l) => !l.startsWith(READ_FILE_NOTE_PREFIX));
+}
+
+describe("windowFileContent — backwards compatibility", () => {
+  it("with no args returns the first 500 lines, as the pre-offset handler did", () => {
+    const result = windowFileContent(numberedFile(1200), {});
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const body = bodyLines(result.content);
+    expect(body).toHaveLength(READ_FILE_DEFAULT_MAX_LINES);
+    expect(body[0]).toBe("line 1");
+    expect(body[499]).toBe("line 500");
+    expect(result.totalLines).toBe(1200);
+    expect(result.truncated).toBe(true);
+    expect(result.startLine).toBe(1);
+    expect(result.endLine).toBe(500);
+  });
+
+  it("does not mark a fully-read file as truncated and appends no note", () => {
+    const result = windowFileContent(numberedFile(10), {});
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.truncated).toBe(false);
+    expect(result.nextOffset).toBeUndefined();
+    expect(result.content).toBe(numberedFile(10));
+    expect(result.content).not.toContain(READ_FILE_NOTE_PREFIX);
+  });
+
+  it("keeps totalLines counting the trailing element of a newline-terminated file", () => {
+    // Pre-existing contract: split("\n") on "a\nb\n" yields ["a","b",""].
+    // Pinned so a future refactor cannot silently redefine totalLines.
+    const result = windowFileContent("a\nb\n", {});
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.totalLines).toBe(3);
+  });
+
+  it("honours max_lines exactly as before when no offset is given", () => {
+    const result = windowFileContent(numberedFile(100), { maxLines: 7 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(bodyLines(result.content)).toEqual([
+      "line 1", "line 2", "line 3", "line 4", "line 5", "line 6", "line 7",
+    ]);
+    expect(result.truncated).toBe(true);
+  });
+});
+
+describe("windowFileContent — offset windows", () => {
+  it("returns the exact requested window, 1-based", () => {
+    const result = windowFileContent(numberedFile(5000), { offset: 3380, maxLines: 5 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(bodyLines(result.content)).toEqual([
+      "line 3380", "line 3381", "line 3382", "line 3383", "line 3384",
+    ]);
+    expect(result.startLine).toBe(3380);
+    expect(result.endLine).toBe(3384);
+    expect(result.totalLines).toBe(5000);
+  });
+
+  it("offset=1 is identical to omitting offset", () => {
+    const withOffset = windowFileContent(numberedFile(50), { offset: 1, maxLines: 10 });
+    const without = windowFileContent(numberedFile(50), { maxLines: 10 });
+    expect(withOffset).toEqual(without);
+  });
+
+  it("reads the final line when offset lands on it", () => {
+    const result = windowFileContent(numberedFile(42), { offset: 42, maxLines: 10 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(bodyLines(result.content)).toEqual(["line 42"]);
+    expect(result.startLine).toBe(42);
+    expect(result.endLine).toBe(42);
+    expect(result.truncated).toBe(false);
+  });
+
+  it("paging with nextOffset walks the whole file with no gaps or repeats", () => {
+    const file = numberedFile(23);
+    const seen: string[] = [];
+    let offset: number | undefined = 1;
+
+    while (offset !== undefined) {
+      const result = windowFileContent(file, { offset, maxLines: 5 });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      seen.push(...bodyLines(result.content));
+      offset = result.nextOffset;
+    }
+
+    expect(seen).toEqual(file.split("\n"));
+  });
+});
+
+describe("windowFileContent — truncation is signalled in the text", () => {
+  it("states the window, the remaining count and the next call to make", () => {
+    const result = windowFileContent(numberedFile(1000), { offset: 100, maxLines: 50 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.truncated).toBe(true);
+    expect(result.nextOffset).toBe(150);
+    expect(result.content).toContain(`${READ_FILE_NOTE_PREFIX} TRUNCATED`);
+    expect(result.content).toContain("showed lines 100-149 of 1000");
+    expect(result.content).toContain("851 more line(s) follow");
+    expect(result.content).toContain("offset=150");
+  });
+
+  it("puts the note last so it cannot be mistaken for a leading line of the file", () => {
+    const result = windowFileContent(numberedFile(1000), { offset: 10, maxLines: 3 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const lines = result.content.split("\n");
+    expect(lines.slice(0, 3)).toEqual(["line 10", "line 11", "line 12"]);
+    expect(lines[lines.length - 1]).toContain(READ_FILE_NOTE_PREFIX);
+  });
+
+  it("notes the skipped prefix when a mid-file window reaches EOF", () => {
+    // Not "truncated" (nothing follows), but the agent still only saw part of
+    // the file — silence here is how a half-read file gets cited as whole.
+    const result = windowFileContent(numberedFile(20), { offset: 15, maxLines: 100 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.truncated).toBe(false);
+    expect(result.nextOffset).toBeUndefined();
+    expect(result.content).toContain("showed lines 15-20 of 20 (end of file)");
+    expect(result.content).toContain("Lines 1-14 were not read");
+  });
+});
+
+describe("windowFileContent — out-of-range and invalid arguments", () => {
+  it("treats an offset past EOF as an empty window, not an error", () => {
+    const result = windowFileContent(numberedFile(10), { offset: 9999 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.totalLines).toBe(10);
+    expect(result.startLine).toBe(9999);
+    expect(result.endLine).toBe(9998); // empty window
+    expect(result.truncated).toBe(false);
+    expect(result.content).toContain("past the end of this file");
+    expect(result.content).toContain("(10 lines total)");
+    expect(bodyLines(result.content)).toEqual([]);
+  });
+
+  it("rejects a 0-based offset and names the convention instead of clamping", () => {
+    const result = windowFileContent(numberedFile(10), { offset: 0 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("1-based");
+    expect(result.error).toContain("offset=1");
+  });
+
+  it("rejects a negative offset", () => {
+    const result = windowFileContent(numberedFile(10), { offset: -5 });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a non-integer offset", () => {
+    const result = windowFileContent(numberedFile(10), { offset: 3.5 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("must be an integer");
+  });
+
+  it("rejects a non-numeric offset", () => {
+    const result = windowFileContent(numberedFile(10), { offset: "start" });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("must be an integer");
+  });
+
+  it("accepts a numeric string, because providers do serialize numbers that way", () => {
+    const result = windowFileContent(numberedFile(100), { offset: "20", maxLines: "3" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(bodyLines(result.content)).toEqual(["line 20", "line 21", "line 22"]);
+  });
+
+  it("rejects max_lines below 1 rather than returning a silently empty read", () => {
+    const result = windowFileContent(numberedFile(10), { maxLines: 0 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("max_lines");
+  });
+
+  it("handles an empty file", () => {
+    const result = windowFileContent("", {});
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.totalLines).toBe(1);
+    expect(result.content).toBe("");
+    expect(result.truncated).toBe(false);
+  });
+});

--- a/packages/core/src/agent/tools/read-file-window.ts
+++ b/packages/core/src/agent/tools/read-file-window.ts
@@ -1,0 +1,203 @@
+/**
+ * Windowed reads for the `read_file` agent tool.
+ *
+ * ## Why this exists
+ *
+ * Before this module `read_file` could only ever return the FIRST `max_lines`
+ * lines of a file (default 500). There was no way to ask for the middle. For
+ * the source-review and kernel-audit workloads that is the dominant read shape:
+ * the agent greps, gets back `fs/xfs/xfs_ioctl.c:3421`, and then needs the 80
+ * lines around 3421 — in a file that is 5000 lines long. The only escape hatch
+ * was to shell out (`run_command: sed -n '3380,3460p' file`), which costs an
+ * extra turn, produces output the loop does not track as a source-file read
+ * (see `_sourceFilesRead` in agent/tools.ts — only `read_file` feeds the
+ * coverage gate), and is a strictly worse interface than the tool that already
+ * exists.
+ *
+ * The second, quieter failure was silent truncation. The old handler returned
+ * `{ content, totalLines, truncated }`. `truncated: true` is technically in the
+ * JSON the model sees, but it is a bare boolean with no instruction attached —
+ * in practice models read the 500 lines, see no more, and reason as if the file
+ * ended there. A finding built on a file the agent only half-read is exactly
+ * the "hallucinated file/line reference" class that AGENTS.md flags as a
+ * HackerOne bright-line violation. So truncation is now stated IN the returned
+ * text, in the imperative, with the exact follow-up call to make.
+ *
+ * ## Why the logic lives here and not in the ToolExecutor
+ *
+ * Same reason as `apply-patch.ts` and `scope-path.ts`: the windowing is pure
+ * (string in, window out) and deserves direct unit tests that do not have to
+ * stand up a `ToolExecutor`, a `ToolContext`, a scope root and a temp dir just
+ * to assert an off-by-one. The handler in agent/tools.ts keeps the I/O and the
+ * scope enforcement; this file keeps the arithmetic.
+ *
+ * ## Line numbering convention
+ *
+ * `offset` is 1-BASED and matches `grep -n` / `rg -n` / `sed -n 'Np'` / the
+ * `file.c:247` citation format used in `evidence_request`. This is deliberate:
+ * the overwhelmingly common call sequence is grep → read around the hit, and a
+ * 0-based offset would make the agent silently read one line off from every
+ * line number the rest of its toolchain reports. A 0-based `offset` is
+ * therefore REJECTED rather than clamped — clamping 0 to 1 would hand back a
+ * window that is right by accident and teach the model nothing, while an error
+ * that names the convention is recovered from in one turn.
+ */
+
+/** Default window size, unchanged from the pre-offset handler. */
+export const READ_FILE_DEFAULT_MAX_LINES = 500;
+
+/**
+ * Marker prefix for the synthetic status line appended to windowed content.
+ *
+ * Namespaced so a reader (human or model) can tell it apart from file content.
+ * It is not a cryptographic delimiter — a file could contain this literal
+ * string — but `read_file` output is already classified UNTRUSTED and passes
+ * through `sanitizeUntrustedToolResult` before it re-enters model context, so
+ * spoofing this line buys an attacker nothing they cannot already do by
+ * writing "ignore previous instructions" into the same file.
+ */
+export const READ_FILE_NOTE_PREFIX = "[pwnkit:read_file]";
+
+/** A resolved window over a file's lines, or a rejected request. */
+export type ReadFileWindow =
+  | {
+      ok: true;
+      /** The selected lines, joined by "\n", plus a trailing status note when relevant. */
+      content: string;
+      /** Total lines in the whole file (not just the window). */
+      totalLines: number;
+      /** 1-based line number of the first line in `content`. */
+      startLine: number;
+      /**
+       * 1-based line number of the last line in `content`. For a window that
+       * starts past EOF this is `startLine - 1`, i.e. an empty window.
+       */
+      endLine: number;
+      /** True when lines AFTER `endLine` were omitted. */
+      truncated: boolean;
+      /** When `truncated`, the `offset` to pass to read the next window. */
+      nextOffset?: number;
+    }
+  | { ok: false; error: string };
+
+/**
+ * Coerce a model-supplied numeric argument.
+ *
+ * Tool arguments arrive as `unknown` because different providers serialize
+ * numbers differently — several pass `"500"` as a string even when the schema
+ * says `type: "number"`. The pre-offset handler tolerated this only by
+ * accident (`Array.prototype.slice` coerces its arguments), so accepting
+ * numeric strings here is preserving existing behaviour, not adding leniency.
+ * Anything that is not an integer at or above `min` is rejected with a message
+ * that states the constraint, because a silently coerced bad offset produces
+ * confidently wrong line citations.
+ */
+function parsePositiveIntArg(
+  value: unknown,
+  name: string,
+  min: number,
+): { ok: true; value: number | undefined } | { ok: false; error: string } {
+  if (value === undefined || value === null) return { ok: true, value: undefined };
+
+  const n = typeof value === "number" ? value : typeof value === "string" ? Number(value.trim()) : NaN;
+
+  if (!Number.isFinite(n) || !Number.isInteger(n)) {
+    return {
+      ok: false,
+      error: `read_file: \`${name}\` must be an integer, got ${JSON.stringify(value)}`,
+    };
+  }
+  if (n < min) {
+    return {
+      ok: false,
+      error:
+        name === "offset"
+          ? `read_file: \`offset\` is 1-based (line 1 is the first line of the file), got ${n}. ` +
+            `Pass offset=1 to read from the start.`
+          : `read_file: \`${name}\` must be >= ${min}, got ${n}`,
+    };
+  }
+  return { ok: true, value: n };
+}
+
+/**
+ * Select a line window out of already-read file content.
+ *
+ * `totalLines` is `content.split("\n").length`, which counts a trailing empty
+ * element for files that end in a newline (so it reads one higher than
+ * `wc -l`). That is the pre-existing contract of this tool's `totalLines`
+ * field and is left alone on purpose: `split("\n")` indices ARE the 1-based
+ * line numbers every other tool in the chain reports, and changing the count
+ * now would silently move the meaning of a field callers already log.
+ *
+ * An `offset` past EOF is NOT an error. It returns an empty window with a note
+ * saying so — the agent asked a well-formed question about a file that is
+ * shorter than it assumed, and the useful answer is "the file has N lines",
+ * not a thrown exception that costs a turn.
+ */
+export function windowFileContent(
+  fileContent: string,
+  args: { offset?: unknown; maxLines?: unknown },
+): ReadFileWindow {
+  const offsetArg = parsePositiveIntArg(args.offset, "offset", 1);
+  if (!offsetArg.ok) return { ok: false, error: offsetArg.error };
+
+  const maxLinesArg = parsePositiveIntArg(args.maxLines, "max_lines", 1);
+  if (!maxLinesArg.ok) return { ok: false, error: maxLinesArg.error };
+
+  const offset = offsetArg.value ?? 1;
+  const maxLines = maxLinesArg.value ?? READ_FILE_DEFAULT_MAX_LINES;
+
+  const lines = fileContent.split("\n");
+  const totalLines = lines.length;
+
+  // Past EOF: empty window, explicit note, still a success.
+  if (offset > totalLines) {
+    return {
+      ok: true,
+      content:
+        `${READ_FILE_NOTE_PREFIX} offset ${offset} is past the end of this file ` +
+        `(${totalLines} lines total). Nothing to read.`,
+      totalLines,
+      startLine: offset,
+      endLine: offset - 1,
+      truncated: false,
+    };
+  }
+
+  const startIdx = offset - 1;
+  const endIdx = Math.min(startIdx + maxLines, totalLines); // exclusive
+  const selected = lines.slice(startIdx, endIdx);
+  const startLine = offset;
+  const endLine = endIdx;
+  const truncated = endIdx < totalLines;
+
+  // State where we are whenever the window is not the whole file. A window
+  // that starts mid-file is just as misleading as one that ends early if the
+  // model forgets it asked for an offset, so the note covers both cases.
+  const notes: string[] = [];
+  if (truncated) {
+    notes.push(
+      `${READ_FILE_NOTE_PREFIX} TRUNCATED — showed lines ${startLine}-${endLine} of ${totalLines}. ` +
+        `${totalLines - endLine} more line(s) follow. ` +
+        `Call read_file again with offset=${endLine + 1} to continue.`,
+    );
+  } else if (startLine > 1) {
+    notes.push(
+      `${READ_FILE_NOTE_PREFIX} showed lines ${startLine}-${endLine} of ${totalLines} (end of file). ` +
+        `Lines 1-${startLine - 1} were not read.`,
+    );
+  }
+
+  const content = notes.length > 0 ? [...selected, ...notes].join("\n") : selected.join("\n");
+
+  return {
+    ok: true,
+    content,
+    totalLines,
+    startLine,
+    endLine,
+    truncated,
+    ...(truncated ? { nextOffset: endLine + 1 } : {}),
+  };
+}

--- a/packages/core/src/agent/tools/system.ts
+++ b/packages/core/src/agent/tools/system.ts
@@ -15,10 +15,18 @@ import type { ToolDefinition } from "../types.js";
 export const systemToolDefinitions: Record<string, ToolDefinition> = {
   read_file: {
     name: "read_file",
-    description: "Read a source code file. Returns numbered lines. Path must be within the scoped directory (usually the package or repo root). Start by reading package.json to understand the project structure, then follow imports.",
+    description:
+      "Read a source code file, or a window of one. Path must be within the scoped directory (usually the package or repo root). " +
+      "Returns raw lines plus startLine/endLine/totalLines for exact file:line citations. " +
+      "Use offset (1-based, matching grep -n and rg -n) to read the middle of a large file. " +
+      "When a window does not reach end-of-file, the result gives the next offset to continue from.",
     parameters: {
       path: { type: "string", description: "File path (relative to scope root or absolute)" },
-      max_lines: { type: "number", description: "Read only the first N lines. Omit to read the whole file (large files are truncated in the middle, keeping both ends)." },
+      max_lines: { type: "number", description: "Max lines to read (default 500). Use for large files." },
+      offset: {
+        type: "number",
+        description: "1-based line number to start reading at (default 1). An offset past EOF returns an empty window with the file length.",
+      },
     },
     required: ["path"],
   },


### PR DESCRIPTION
## Scope
Ports 1-based windowed `read_file` support with explicit truncation guidance, exact line metadata, and scope-preserving executor integration.

## Verification
- pnpm build
- pnpm lint
- pnpm test:public: passed
- focused read window tests: 207 passed
- Foxguard diff: zero new high/critical findings
- Secret scan findings are fixture-only