### PR TITLE
fix(runtime): preserve cross-family hunt refuters

### DIFF
--- a/packages/core/src/runtime/llm-api.test.ts
+++ b/packages/core/src/runtime/llm-api.test.ts
@@ -41,6 +41,8 @@ describe("LlmApiRuntime provider detection", () => {
     delete process.env.Z_AI_API_KEY;
     delete process.env.Z_AI_BASE_URL;
     delete process.env.PWNKIT_MODEL;
+    delete process.env.PWNKIT_SELECTED_PROVIDER;
+    delete process.env.PWNKIT_FORCE_PROVIDER;
     delete process.env.PWNKIT_REGION_OVERRIDE;
     delete process.env.PWNKIT_CHATGPT_ACCESS_TOKEN;
     delete process.env.PWNKIT_CHATGPT_OAUTH_REFRESH_TOKEN;
@@ -133,6 +135,25 @@ describe("LlmApiRuntime provider detection", () => {
 
     expect(rt.getConfigurationDiagnostics().provider).toBe("azure");
     expect(rt.resolvedModel()).toBe("future-foundry-deployment");
+  });
+
+  it("routes a cross-family refuter model past the primary provider pin", () => {
+    // Test fixtures, literal non-secret keys.
+    // foxguard: ignore[js/no-hardcoded-secret]
+    process.env.AZURE_OPENAI_API_KEY = "azure-primary-key";
+    process.env.AZURE_OPENAI_BASE_URL = "https://azure.example/openai/v1";
+    // foxguard: ignore[js/no-hardcoded-secret]
+    process.env.ANTHROPIC_API_KEY = "sk-ant-refuter-key";
+    process.env.PWNKIT_MODEL = "gpt-5.5";
+    process.env.PWNKIT_SELECTED_PROVIDER = "azure";
+
+    const rt = new LlmApiRuntime({
+      type: "api",
+      timeout: 5000,
+      model: "claude-sonnet-4-6",
+    });
+
+    expect(rt.getConfigurationDiagnostics().provider).toBe("anthropic");
   });
 
   it("selects Anthropic when ANTHROPIC_API_KEY is set", async () => {

--- a/packages/core/src/runtime/llm-api.ts
+++ b/packages/core/src/runtime/llm-api.ts
@@ -1235,11 +1235,20 @@ function detectProvider(configApiKey?: string, preferredModel?: string): {
       "PWNKIT_SELECTED_PROVIDER conflicts with PWNKIT_FORCE_PROVIDER",
     );
   }
-  const pinnedProviderRaw = selectedProviderRaw ?? forcedProviderRaw;
+  // The worker pin chooses the primary scan provider. A hunt's refuter creates
+  // a runtime with a different explicit model; honoring the primary pin there
+  // would route that model through the wrong credential and defeat cross-family
+  // refutation. PWNKIT_FORCE_PROVIDER remains an unconditional benchmark guard.
+  const primaryModel = process.env.PWNKIT_MODEL?.trim();
+  const selectedProviderApplies =
+    !preferredModel || !primaryModel || preferredModel === primaryModel;
+  const pinnedProviderRaw =
+    forcedProviderRaw ??
+    (selectedProviderApplies ? selectedProviderRaw : undefined);
   if (pinnedProviderRaw) {
-    const source = selectedProviderRaw
-      ? "PWNKIT_SELECTED_PROVIDER"
-      : "PWNKIT_FORCE_PROVIDER";
+    const source = pinnedProviderRaw === forcedProviderRaw
+      ? "PWNKIT_FORCE_PROVIDER"
+      : "PWNKIT_SELECTED_PROVIDER";
     const supported: readonly ApiProvider[] = [
       "openrouter",
       "anthropic",


### PR DESCRIPTION
Prevents `PWNKIT_SELECTED_PROVIDER` from overriding a hunt refuter runtime that explicitly selects a different model family. The primary cloud route remains pinned; `PWNKIT_FORCE_PROVIDER` remains unconditional.\n\nValidated: `pnpm --filter @pwnkit/core exec vitest run src/runtime/llm-api.test.ts`; `pnpm --filter @pwnkit/core build`.\n\nThe 0cloud runtime image remains pinned to its current digest; this source fix needs the normal image-release flow before deployment.