### PR TITLE
fix(memsafety): contain retained fuzz artifacts

### DIFF
--- a/packages/cli/src/commands/__tests__/memsafety.test.ts
+++ b/packages/cli/src/commands/__tests__/memsafety.test.ts
@@ -1,10 +1,21 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { detectMemSafetyBuild, registerMemsafetyCommand } from "../memsafety.js";
+import {
+  detectMemSafetyBuild,
+  registerMemsafetyCommand,
+  resolveArtifactDir,
+} from "../memsafety.js";
 
 const core = vi.hoisted(() => ({
   getCloudSinkConfig: vi.fn(),
@@ -125,5 +136,37 @@ describe("registerMemsafetyCommand", () => {
       }),
     );
     expect(stdout).toHaveBeenCalled();
+  });
+});
+
+describe("resolveArtifactDir", () => {
+  it("rejects a symlinked artifact root that resolves into prepared source", () => {
+    const root = mkdtempSync(join(tmpdir(), "pwnkit-memsafety-artifact-"));
+    const sourceRoot = join(root, "source");
+    const outsideRoot = join(root, "outside");
+    const artifactLink = join(outsideRoot, "retained");
+    try {
+      mkdirSync(sourceRoot);
+      mkdirSync(outsideRoot);
+      symlinkSync(sourceRoot, artifactLink);
+
+      expect(() => resolveArtifactDir(artifactLink, sourceRoot)).toThrow(
+        /outside the prepared source tree/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps an ordinary external artifact root", () => {
+    const root = mkdtempSync(join(tmpdir(), "pwnkit-memsafety-artifact-"));
+    const sourceRoot = join(root, "source");
+    const artifactRoot = join(root, "artifacts");
+    try {
+      mkdirSync(sourceRoot);
+      expect(resolveArtifactDir(artifactRoot, sourceRoot)).toBe(realpathSync(artifactRoot));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/commands/memsafety.ts
+++ b/packages/cli/src/commands/memsafety.ts
@@ -28,7 +28,7 @@
  */
 
 import type { Command } from "commander";
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, realpathSync, writeFileSync } from "node:fs";
 import { resolve, join, sep } from "node:path";
 import type { RuntimeMode } from "@pwnkit/shared";
 import type { MemSafetyTarget } from "@pwnkit/core";
@@ -75,6 +75,32 @@ export function detectMemSafetyBuild(
   return null;
 }
 
+/**
+ * Resolve a caller-selected evidence root and prevent the prepared source
+ * cleanup from deleting retained proof. A relative root is allowed for local
+ * use but is normalized before the containment check.
+ */
+export function resolveArtifactDir(
+  value: string | undefined,
+  sourceRoot: string,
+): string | undefined {
+  const raw = value?.trim();
+  if (!raw) return undefined;
+  const artifactDir = resolve(raw);
+  const preparedRoot = realpathSync(sourceRoot);
+  mkdirSync(artifactDir, { recursive: true, mode: 0o700 });
+  const canonicalArtifactDir = realpathSync(artifactDir);
+  if (
+    canonicalArtifactDir === preparedRoot ||
+    canonicalArtifactDir.startsWith(`${preparedRoot}${sep}`)
+  ) {
+    throw new Error(
+      "--artifact-dir must resolve outside the prepared source tree",
+    );
+  }
+  return canonicalArtifactDir;
+}
+
 export interface RunMemSafetyOptions {
   /** Source tree to fuzz — a local path or a git URL (resolved via prepare). */
   target: string;
@@ -95,17 +121,21 @@ export interface RunMemSafetyOptions {
   runMiri?: boolean;
   /** Fuzz wall-clock budget in seconds (maps to libFuzzer -max_total_time). */
   fuzzTimeoutSec?: number;
+  /**
+   * Persist bounded crash evidence outside the prepared source tree. The
+   * runner writes only copied reproducers, sanitizer logs, and a manifest;
+   * it never retains the cloned target itself.
+   */
+  artifactDir?: string;
+  /**
+   * Aggregate byte ceiling for the retained proof directory. The engine
+   * reserves room for its manifest and never truncates a reproducer.
+   */
+  artifactMaxBytes?: number;
   runtime?: RuntimeMode;
   /** Clone timeout budget in ms, forwarded to prepare(). */
   timeoutMs?: number;
   log?: (msg: string) => void;
-  /**
-   * Optional persistent root for bounded crash evidence. The caller owns its
-   * lifecycle; pwnkit never archives the source checkout beneath it.
-   */
-  artifactDir?: string;
-  /** Total retained crash-evidence byte ceiling paired with `artifactDir`. */
-  artifactMaxBytes?: number;
 }
 
 export interface MemSafetyOutcome {
@@ -175,6 +205,8 @@ export async function runMemSafety(opts: RunMemSafetyOptions): Promise<MemSafety
       ...(opts.fuzzDir ? { fuzzDir: opts.fuzzDir } : {}),
     };
 
+    const artifactDir = resolveArtifactDir(opts.artifactDir, sourceRoot);
+
     // Capture the cloud-sink config; the stage does NO I/O (posts nothing), so
     // we post its findings ourselves — the same discovered-candidate path
     // deep-review uses. No-op when not in cloud mode (sinkCfg null).
@@ -185,7 +217,7 @@ export async function runMemSafety(opts: RunMemSafetyOptions): Promise<MemSafety
       fuzz: {
         ...(opts.runMiri != null ? { runMiri: opts.runMiri } : {}),
         ...(opts.fuzzTimeoutSec ? { timeoutSec: opts.fuzzTimeoutSec } : {}),
-        ...(opts.artifactDir ? { artifactDir: opts.artifactDir } : {}),
+        ...(artifactDir ? { artifactDir } : {}),
         ...(opts.artifactMaxBytes !== undefined
           ? { artifactMaxBytes: opts.artifactMaxBytes }
           : {}),
@@ -267,9 +299,9 @@ interface MemSafetyCliOpts {
   harness?: string;
   fuzzDir?: string;
   miri?: boolean;
-  fuzzTimeout?: string;
   artifactDir?: string;
   artifactMaxBytes?: string;
+  fuzzTimeout?: string;
   runtime?: string;
   format?: string;
   output?: string;
@@ -378,18 +410,15 @@ export function registerMemsafetyCommand(program: Command): void {
       "--build-system <sys>",
       "Force the build system: cargo | cmake | autotools | meson | make (else auto-detected)",
     )
+    .option("--artifact-dir <path>", "Persist bounded crash evidence outside the source tree")
+    .option(
+      "--artifact-max-bytes <bytes>",
+      "Aggregate byte ceiling for retained crash evidence (default 4194304)",
+    )
     .option("--harness <name>", "libFuzzer / cargo-fuzz harness target name")
     .option("--fuzz-dir <path>", "Non-standard cargo-fuzz directory (relative to source root)")
     .option("--miri", "Additionally run `cargo +nightly miri` for UB detection (Rust)", false)
     .option("--fuzz-timeout <sec>", "Fuzz wall-clock budget in seconds (default 60)")
-    .option(
-      "--artifact-dir <path>",
-      "Persist bounded crash evidence below this directory",
-    )
-    .option(
-      "--artifact-max-bytes <bytes>",
-      "Total retained crash-evidence byte ceiling (requires --artifact-dir)",
-    )
     .option("--format <fmt>", "Output format (json)", "json")
     .option("--output <path>", "Write the result JSON to this path instead of stdout")
     .option("--runtime <mode>", "Engine runtime (default api)")

--- a/packages/core/src/stages/memsafety-scan.ts
+++ b/packages/core/src/stages/memsafety-scan.ts
@@ -148,12 +148,13 @@ export function crashArtifactToFinding(
   const category = memPrimitiveToCategory(exploitability.primitive);
   const stackSummary = (crash.stack ?? []).slice(0, 5).join(" → ");
 
+  const reproducerRef = crash.artifactRef ?? crash.inputPath;
   const reproduced = verdict.verdict === "confirmed";
   const description = [
     `Userspace ${crash.kind} crash in ${target.language} target (${target.sourceRoot}).`,
     `Primitive: ${exploitability.primitive} (op=${exploitability.readWrite}, controllable=${exploitability.controllable}).`,
     stackSummary ? `Stack: ${stackSummary}.` : "",
-    crash.inputPath ? `Reproducing input: ${crash.inputPath}.` : "",
+    reproducerRef ? `Reproducing input: ${reproducerRef}.` : "",
     reproduced
       ? "Reproduced under the sanitizer/Miri build (memory-corruption PoC)."
       : "Observed crash; not yet a reproduced memory-corruption PoC (inconclusive — not a rejection).",
@@ -191,7 +192,7 @@ export function crashArtifactToFinding(
     category,
     status: "discovered",
     evidence: {
-      request: crash.inputPath ?? "N/A (userspace crash artifact)",
+      request: reproducerRef ?? "N/A (userspace crash artifact)",
       response:
         rawOut.length > 4000 ? rawOut.slice(0, 4000) + "\n... [truncated]" : rawOut,
       analysis: analysisLines.join("\n"),

--- a/packages/core/src/triage/memsafety-types.ts
+++ b/packages/core/src/triage/memsafety-types.ts
@@ -51,6 +51,12 @@ export interface CrashArtifact {
   rawOutput: string;
   /** Path to the reproducing input, when one was saved. */
   inputPath?: string;
+  /**
+   * Archive-relative location of the copied reproducer, when evidence
+   * retention was requested. Unlike inputPath this is safe to publish in a
+   * finding because it does not reveal the sandbox's filesystem layout.
+   */
+  artifactRef?: string;
   /** Symbolised stack frames, when available. */
   stack?: string[];
   primitive?: MemPrimitive;

--- a/packages/core/src/triage/userspace-fuzz-runner.test.ts
+++ b/packages/core/src/triage/userspace-fuzz-runner.test.ts
@@ -5,6 +5,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -260,7 +261,23 @@ describe("runUserspaceFuzzLoop — cargo-fuzz harness discovery", () => {
     expect(result.crashes).toEqual([]);
   });
 
-  it("retains a bounded cargo-fuzz reproducer outside the source tree", async () => {
+  it("removes an empty persistent artifact directory after a no-crash run", async () => {
+    const sourceRoot = useFakeCargo(["only_target"]);
+    const retainedRoot = mkdtempSync(join(tmpdir(), "pwnkit-retained-artifacts-"));
+    fakeCargoDirs.push(retainedRoot);
+
+    await runUserspaceFuzzLoop({
+      target: { language: "rust", sourceRoot, buildSystem: "cargo" },
+      artifactDir: retainedRoot,
+      logger: () => {},
+    });
+
+    expect(readdirSync(retainedRoot)).not.toContainEqual(
+      expect.stringMatching(/^pwnkit-uf-/),
+    );
+  });
+
+  it("attaches a cargo-fuzz artifact input to a captured Rust crash", async () => {
     const sourceRoot = useFakeCargo(["only_target"], ASAN_OOB_WRITE);
     const sourceArtifactDir = join(
       sourceRoot,
@@ -283,46 +300,111 @@ describe("runUserspaceFuzzLoop — cargo-fuzz harness discovery", () => {
 
     expect(result.crashes).toHaveLength(1);
     expect(result.crashes[0]!.kind).toBe("asan");
-    expect(result.crashes[0]!.inputPath).toMatch(
-      new RegExp(`^${retainedRoot}/pwnkit-uf-`),
+    expect(result.crashes[0]!.inputPath).toContain(
+      `${retainedRoot}/pwnkit-uf-`,
     );
-    expect(readFileSync(result.crashes[0]!.inputPath!, "utf8")).toBe(
-      "reproducer",
-    );
-    const manifest = JSON.parse(
-      readFileSync(
-        join(dirname(dirname(result.crashes[0]!.inputPath!)), "manifest.json"),
-        "utf8",
-      ),
-    ) as {
-      schema: string;
-      run: Record<string, unknown>;
-      crashes: Array<Record<string, unknown>>;
-    };
-    expect(manifest.schema).toBe("pwnkit-memsafety-artifact/v1");
-    expect(manifest.run).toMatchObject({
-      language: "rust",
-      build_system: "cargo",
-      harness: "only_target",
-    });
-    expect(manifest.crashes[0]?.reproducer).toMatch(/^reproducers\//);
-    expect(JSON.stringify(manifest)).not.toContain(sourceRoot);
   });
 
-  it("records an omitted over-budget reproducer without claiming it survived", async () => {
+  it("retains bounded reproducers and crash logs beneath an explicit artifact root", async () => {
     const sourceRoot = useFakeCargo(["only_target"], ASAN_OOB_WRITE);
-    const sourceArtifactDir = join(
-      sourceRoot,
-      "fuzz",
-      "artifacts",
-      "only_target",
-    );
+    const sourceArtifactDir = join(sourceRoot, "fuzz", "artifacts", "only_target");
+    const sourceInput = join(sourceArtifactDir, "crash-deadbeef");
     mkdirSync(sourceArtifactDir, { recursive: true });
-    writeFileSync(
-      join(sourceArtifactDir, "crash-deadbeef"),
-      Buffer.alloc(64 * 1024),
+    writeFileSync(sourceInput, "reproducer", "utf8");
+    const retainedRoot = mkdtempSync(join(tmpdir(), "pwnkit-retained-artifacts-"));
+    fakeCargoDirs.push(retainedRoot);
+
+    const result = await runUserspaceFuzzLoop({
+      target: { language: "rust", sourceRoot, buildSystem: "cargo" },
+      artifactDir: retainedRoot,
+      logger: () => {},
+    });
+
+    const crash = result.crashes[0]!;
+    const runName = readdirSync(retainedRoot).find((name) =>
+      name.startsWith("pwnkit-uf-"),
+    )!;
+    const reproducerRef = `${runName}/reproducers/${crash.signature}.input`;
+    const reproducerPath = join(retainedRoot, reproducerRef);
+
+    expect(readFileSync(reproducerPath, "utf8")).toBe("reproducer");
+    expect(crash.inputPath).toBe(reproducerPath);
+    expect(crash.artifactRef).toBe(reproducerRef);
+    expect(readFileSync(join(retainedRoot, runName, "logs", `${crash.signature}.log`), "utf8"))
+      .toContain("AddressSanitizer");
+    expect(
+      JSON.parse(readFileSync(join(retainedRoot, runName, "manifest.json"), "utf8")),
+    ).toMatchObject({
+      schema: "pwnkit-memsafety-artifacts/v1",
+      crashes: [
+        {
+          signature: crash.signature,
+          reproducer: { ref: reproducerRef },
+        },
+      ],
+    });
+  });
+
+  it("does not follow a source-tree reproducer symlink into retained evidence", async () => {
+    const sourceRoot = useFakeCargo(["only_target"], ASAN_OOB_WRITE);
+    const sourceArtifactDir = join(sourceRoot, "fuzz", "artifacts", "only_target");
+    const outside = join(tmpdir(), `pwnkit-outside-${Date.now()}`);
+    const sourceInput = join(sourceArtifactDir, "crash-deadbeef");
+    mkdirSync(sourceArtifactDir, { recursive: true });
+    writeFileSync(outside, "must not retain", "utf8");
+    symlinkSync(outside, sourceInput);
+    const retainedRoot = mkdtempSync(join(tmpdir(), "pwnkit-retained-artifacts-"));
+    fakeCargoDirs.push(retainedRoot, outside);
+
+    const result = await runUserspaceFuzzLoop({
+      target: { language: "rust", sourceRoot, buildSystem: "cargo" },
+      artifactDir: retainedRoot,
+      logger: () => {},
+    });
+
+    expect(result.crashes[0]!.artifactRef).toBeUndefined();
+    const runName = readdirSync(retainedRoot).find((name) =>
+      name.startsWith("pwnkit-uf-"),
+    )!;
+    const manifest = JSON.parse(
+      readFileSync(join(retainedRoot, runName, "manifest.json"), "utf8"),
     );
-    const retainedRoot = mkdtempSync(join(tmpdir(), "pwnkit-retained-proof-"));
+    expect(manifest.crashes[0].reproducer).toBeNull();
+  });
+
+  it("does not follow a symlinked artifact-directory ancestor into retained evidence", async () => {
+    const sourceRoot = useFakeCargo(["only_target"], ASAN_OOB_WRITE);
+    const sourceArtifactRoot = join(sourceRoot, "fuzz", "artifacts");
+    const outsideDir = mkdtempSync(join(tmpdir(), "pwnkit-outside-artifacts-"));
+    mkdirSync(sourceArtifactRoot, { recursive: true });
+    writeFileSync(join(outsideDir, "crash-deadbeef"), "must not retain", "utf8");
+    symlinkSync(outsideDir, join(sourceArtifactRoot, "only_target"));
+    const retainedRoot = mkdtempSync(join(tmpdir(), "pwnkit-retained-artifacts-"));
+    fakeCargoDirs.push(retainedRoot, outsideDir);
+
+    const result = await runUserspaceFuzzLoop({
+      target: { language: "rust", sourceRoot, buildSystem: "cargo" },
+      artifactDir: retainedRoot,
+      logger: () => {},
+    });
+
+    expect(result.crashes[0]!.artifactRef).toBeUndefined();
+    const runName = readdirSync(retainedRoot).find((name) =>
+      name.startsWith("pwnkit-uf-"),
+    )!;
+    const manifest = JSON.parse(
+      readFileSync(join(retainedRoot, runName, "manifest.json"), "utf8"),
+    );
+    expect(manifest.crashes[0].reproducer).toBeNull();
+  });
+
+  it("keeps proof copies below the aggregate artifact budget", async () => {
+    const sourceRoot = useFakeCargo(["only_target"], ASAN_OOB_WRITE);
+    const sourceArtifactDir = join(sourceRoot, "fuzz", "artifacts", "only_target");
+    const sourceInput = join(sourceArtifactDir, "crash-deadbeef");
+    mkdirSync(sourceArtifactDir, { recursive: true });
+    writeFileSync(sourceInput, Buffer.alloc(128 * 1024, 7));
+    const retainedRoot = mkdtempSync(join(tmpdir(), "pwnkit-retained-artifacts-"));
     fakeCargoDirs.push(retainedRoot);
 
     const result = await runUserspaceFuzzLoop({
@@ -332,16 +414,18 @@ describe("runUserspaceFuzzLoop — cargo-fuzz harness discovery", () => {
       logger: () => {},
     });
 
-    expect(result.crashes).toHaveLength(1);
-    expect(result.crashes[0]!.inputPath).toBeUndefined();
-    const runDir = join(
-      retainedRoot,
-      readdirSync(retainedRoot).find((name) => name.startsWith("pwnkit-uf-"))!,
-    );
+    const crash = result.crashes[0]!;
+    const runName = readdirSync(retainedRoot).find((name) =>
+      name.startsWith("pwnkit-uf-"),
+    )!;
     const manifest = JSON.parse(
-      readFileSync(join(runDir, "manifest.json"), "utf8"),
-    ) as { crashes: Array<Record<string, unknown>> };
-    expect(manifest.crashes[0]?.reproducer_omitted).toMatch(/budget/);
+      readFileSync(join(retainedRoot, runName, "manifest.json"), "utf8"),
+    );
+    expect(crash.artifactRef).toBeUndefined();
+    expect(manifest.crashes[0]).toMatchObject({
+      reproducer: null,
+      log: null,
+    });
   });
 
   it("does not discover a cargo-fuzz target outside the source root", async () => {
@@ -354,9 +438,58 @@ describe("runUserspaceFuzzLoop — cargo-fuzz harness discovery", () => {
 
     expect(result.executedHarness).toBeUndefined();
     expect(result.iterations).toBe(0);
-    expect(result.toolingMissing).toContain("cargo-fuzz-harness");
+    expect(result.toolingMissing).toContain("cargo-fuzz-layout");
   });
 
+
+  it("rejects traversal fuzz directories and harness names before cargo execution", async () => {
+    const sourceRoot = useFakeCargo(["only_target"]);
+    const traversal = await runUserspaceFuzzLoop({
+      target: {
+        language: "rust",
+        sourceRoot,
+        buildSystem: "cargo",
+        fuzzDir: "../outside",
+      },
+      logger: () => {},
+    });
+    const invalidHarness = await runUserspaceFuzzLoop({
+      target: {
+        language: "rust",
+        sourceRoot,
+        buildSystem: "cargo",
+        harnessEntry: "../outside",
+      },
+      logger: () => {},
+    });
+
+    expect(traversal.iterations).toBe(0);
+    expect(traversal.toolingMissing).toContain("cargo-fuzz-layout");
+    expect(invalidHarness.iterations).toBe(0);
+    expect(invalidHarness.toolingMissing).toContain("cargo-fuzz-layout");
+  });
+
+  it("supports an ordinary non-standard in-root fuzz directory", async () => {
+    const sourceRoot = useFakeCargo(["only_target"]);
+    const fuzzDir = join(sourceRoot, "crates", "fuzz");
+    mkdirSync(fuzzDir, { recursive: true });
+
+    const result = await runUserspaceFuzzLoop({
+      target: {
+        language: "rust",
+        sourceRoot,
+        buildSystem: "cargo",
+        fuzzDir: "crates/fuzz",
+        harnessEntry: "only_target",
+      },
+      logger: () => {},
+    });
+
+    expect(result.toolingMissing).toBeUndefined();
+
+    expect(result.executedHarness).toBe("only_target");
+    expect(result.iterations).toBe(1);
+  });
   it("fails closed when cargo-fuzz has no harnesses", async () => {
     const sourceRoot = useFakeCargo([]);
     const result = await runUserspaceFuzzLoop({

--- a/packages/core/src/triage/userspace-fuzz-runner.ts
+++ b/packages/core/src/triage/userspace-fuzz-runner.ts
@@ -19,23 +19,28 @@
  * with an actionable install hint and return an empty-but-honest result
  * rather than fabricating a crash or a clean run.
  *
- * Side-effect discipline: the only writes happen under a per-run artifact
- * directory (an `mkdtemp` under `os.tmpdir()` unless an `artifactDir` is
- * supplied), mirroring the kernel runner. We never write into the target
- * source tree.
+ * Evidence copies are persisted under a per-run artifact directory (an
+ * `mkdtemp` under `os.tmpdir()` unless an `artifactDir` is supplied), mirroring
+ * the kernel runner. A fuzz tool may write its own transient input under the
+ * prepared source tree; only bounded regular-file copies survive cleanup.
  */
 
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
-import { join, resolve, dirname } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
-  copyFileSync,
+  closeSync,
+  constants,
   existsSync,
+  fstatSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
+  readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -48,6 +53,14 @@ import type {
   MemPrimitive,
   MemSafetyTarget,
 } from "./memsafety-types.js";
+
+const MEMSAFETY_ARTIFACT_SCHEMA = "pwnkit-memsafety-artifacts/v1";
+const MAX_RETAINED_CRASHES = 16;
+const MAX_RETAINED_REPRODUCER_BYTES = 1024 * 1024;
+const MAX_RETAINED_LOG_BYTES = 256 * 1024;
+const DEFAULT_RETAINED_ARTIFACT_BYTES = 4 * 1024 * 1024;
+const MIN_RETAINED_ARTIFACT_BYTES = 64 * 1024;
+const ARTIFACT_MANIFEST_RESERVE_BYTES = 64 * 1024;
 
 // ────────────────────────────────────────────────────────────────────
 // Options
@@ -79,19 +92,15 @@ export interface UserspaceFuzzOptions {
    */
   artifactDir?: string;
   /**
-   * Total byte ceiling for persisted crash evidence. Omitted retains the
-   * existing local-research behavior; the cloud CLI requires this whenever it
-   * supplies `artifactDir`.
+   * Aggregate byte ceiling for retained regular-file copies and the manifest.
+   * Omitted retains local-research behavior; callers should set a value below
+   * their archive transport cap so gzip/tar framing cannot exceed it.
    */
   artifactMaxBytes?: number;
   /** Custom logger; defaults to `console.log`. Matches the kernel runner. */
   logger?: (line: string) => void;
 }
 
-const MEMSAFETY_ARTIFACT_SCHEMA = "pwnkit-memsafety-artifact/v1";
-const MIN_ARTIFACT_BYTES = 64 * 1024;
-const MANIFEST_RESERVE_BYTES = 8 * 1024;
-const MAX_RETAINED_LOG_BYTES = 64 * 1024;
 
 // ────────────────────────────────────────────────────────────────────
 // Tooling detection (degrade-when-absent, like QEMU/kernel-build inputs)
@@ -396,12 +405,65 @@ function dedupeBySignature(crashes: CrashArtifact[]): CrashArtifact[] {
   return Array.from(seen.values());
 }
 
+function pathIsWithin(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel === "" || (
+    rel !== ".." &&
+    !rel.startsWith(`..${sep}`) &&
+    !isAbsolute(rel)
+  );
+}
+
+
+function resolveCargoFuzzDir(
+  sourceRoot: string,
+  fuzzDir: string | undefined,
+): string | undefined {
+  const raw = fuzzDir?.trim() || "fuzz";
+  if (isAbsolute(raw)) return undefined;
+  const candidate = resolve(sourceRoot, raw);
+  if (!pathIsWithin(sourceRoot, candidate)) return undefined;
+  try {
+    const canonical = realpathSync(candidate);
+    return canonical === candidate && pathIsWithin(sourceRoot, canonical)
+      ? canonical
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isCargoFuzzHarnessName(value: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(value);
+}
+
+function isStableSourceDirectory(sourceRoot: string, directory: string): boolean {
+  try {
+    const canonical = realpathSync(directory);
+    return canonical === directory && pathIsWithin(sourceRoot, canonical);
+  } catch {
+    return false;
+  }
+}
+
+function resolveArtifactRoot(
+  artifactDir: string | undefined,
+  sourceRoot: string,
+): string | undefined {
+  if (!artifactDir) return undefined;
+  mkdirSync(artifactDir, { recursive: true, mode: 0o700 });
+  const canonical = realpathSync(artifactDir);
+  if (pathIsWithin(sourceRoot, canonical)) {
+    throw new Error("artifactDir must resolve outside the prepared source tree");
+  }
+  return artifactDir;
+}
+
 function makeArtifactDir(artifactDir: string | undefined): {
   dir: string;
   ephemeral: boolean;
 } {
   if (artifactDir) {
-    mkdirSync(artifactDir, { recursive: true });
     return { dir: mkdtempSync(join(artifactDir, "pwnkit-uf-")), ephemeral: false };
   }
   return { dir: mkdtempSync(join(tmpdir(), "pwnkit-uf-")), ephemeral: true };
@@ -433,172 +495,255 @@ export async function runUserspaceFuzzLoop(
   opts: UserspaceFuzzOptions,
 ): Promise<FuzzLoopResult> {
   const log = opts.logger ?? ((line: string) => console.log(line));
+  const sourceRoot = resolve(opts.target.sourceRoot);
+  const canonicalSourceRoot = existsSync(sourceRoot)
+    ? realpathSync(sourceRoot)
+    : sourceRoot;
+  const runOpts: UserspaceFuzzOptions = {
+    ...opts,
+    target: { ...opts.target, sourceRoot: canonicalSourceRoot },
+  };
   const start = Date.now();
   const timeoutSec =
     opts.timeoutSec ??
     parseInt(process.env.PWNKIT_USERSPACE_FUZZ_TIMEOUT_SEC?.trim() || "60", 10);
   const timeoutMs = Math.max(1, timeoutSec) * 1000;
-
-  const { dir: workDir, ephemeral } = makeArtifactDir(opts.artifactDir);
+  const artifactDir = resolveArtifactRoot(opts.artifactDir, canonicalSourceRoot);
+  const artifactMaxBytes = artifactDir
+    ? resolveRetainedArtifactBytes(opts.artifactMaxBytes)
+    : null;
+  const { dir: workDir, ephemeral } = makeArtifactDir(artifactDir);
   const toolingMissing: string[] = [];
+  let retained = false;
 
   try {
     const result =
-      opts.target.language === "rust"
-        ? await runRustLoop(opts, {
-            workDir,
-            timeoutMs,
-            toolingMissing,
-            log,
-            start,
-          })
-        : await runCLoop(opts, { workDir, timeoutMs, toolingMissing, log, start });
-    if (!ephemeral && result.crashes.length > 0) {
-      retainMemsafetyArtifacts({
-        artifactDir: workDir,
-        crashes: result.crashes,
-        maxBytes: opts.artifactMaxBytes,
-        run: {
-          language: opts.target.language,
-          build_system: opts.target.buildSystem,
-          fuzz_dir: opts.target.fuzzDir ?? "fuzz",
-          harness: result.executedHarness ?? opts.target.harnessEntry ?? null,
-          iterations: result.iterations,
-          corpus_size: result.corpusSize,
-          duration_ms: result.durationMs,
-        },
-      });
+      runOpts.target.language === "rust"
+        ? await runRustLoop(runOpts, { workDir, timeoutMs, toolingMissing, log, start })
+        : await runCLoop(runOpts, { workDir, timeoutMs, toolingMissing, log, start });
+    if (!ephemeral && artifactMaxBytes !== null) {
+      retained = persistCapturedArtifacts(
+        result,
+        workDir,
+        canonicalSourceRoot,
+        artifactMaxBytes,
+        log,
+      );
     }
     return result;
   } finally {
-    if (ephemeral) rmSync(workDir, { recursive: true, force: true });
+    if (ephemeral || !retained) rmSync(workDir, { recursive: true, force: true });
   }
 }
 
-interface RetainMemsafetyArtifactsInput {
-  artifactDir: string;
-  crashes: CrashArtifact[];
-  maxBytes: number | undefined;
-  run: Record<string, string | number | null>;
-}
+type ArtifactFile = {
+  ref: string;
+  sha256: string;
+  sizeBytes: number;
+  truncated?: boolean;
+};
 
 /**
- * Retain only the bounded proof needed to re-run an observed crash. Source
- * checkouts and fuzz corpora stay outside this directory. A missing or
- * oversized input clears `CrashArtifact.inputPath`, so downstream PoV grading
- * cannot claim that a reproducer survived when it did not.
+ * Copy only the reproducible portion of a fuzz result into the caller-owned
+ * artifact root. The source tree is attacker-controlled, so symlinks and
+ * over-limit files are rejected instead of followed into an evidence archive.
+ * The aggregate source-byte budget leaves a fixed manifest reserve, ensuring
+ * every finished directory is safe to package below the controller transport
+ * ceiling.
  */
-function retainMemsafetyArtifacts(input: RetainMemsafetyArtifactsInput): void {
-  const maxBytes = requireArtifactLimit(input.maxBytes);
-  let availableBytes = maxBytes - MANIFEST_RESERVE_BYTES;
-  const records: Array<Record<string, unknown>> = [];
+function persistCapturedArtifacts(
+  result: FuzzLoopResult,
+  workDir: string,
+  sourceRoot: string,
+  maxBytes: number,
+  log: (line: string) => void,
+): boolean {
+  if (result.crashes.length === 0) return false;
 
-  for (const [index, crash] of input.crashes.entries()) {
-    const ordinal = String(index + 1).padStart(2, "0");
-    const record: Record<string, unknown> = {
-      signature: crash.signature,
-      kind: crash.kind,
-      primitive: crash.primitive ?? null,
-      stack: (crash.stack ?? []).slice(0, 10).map((frame) => frame.slice(0, 256)),
-    };
-    const logBytes = Buffer.from(crash.rawOutput ?? "", "utf8");
-    const retainedLogBytes = Math.min(
-      logBytes.byteLength,
-      MAX_RETAINED_LOG_BYTES,
-      availableBytes,
+  const runDir = basename(workDir);
+  const logsDir = join(workDir, "logs");
+  const reproducersDir = join(workDir, "reproducers");
+  mkdirSync(logsDir, { recursive: true, mode: 0o700 });
+  mkdirSync(reproducersDir, { recursive: true, mode: 0o700 });
+  let remaining = maxBytes - ARTIFACT_MANIFEST_RESERVE_BYTES;
+
+  const crashes = result.crashes
+    .slice(0, MAX_RETAINED_CRASHES)
+    .map((crash, index) => {
+      const id = safeArtifactId(crash.signature, index);
+      let reproducer: ArtifactFile | null = null;
+      if (crash.inputPath && remaining > 0) {
+        const reproducerRef = `${runDir}/reproducers/${id}.input`;
+        reproducer = copyBoundedReproducer(
+          crash.inputPath,
+          join(reproducersDir, `${id}.input`),
+          reproducerRef,
+          sourceRoot,
+          Math.min(MAX_RETAINED_REPRODUCER_BYTES, remaining),
+        );
+        if (reproducer) {
+          remaining -= reproducer.sizeBytes;
+          crash.inputPath = join(reproducersDir, `${id}.input`);
+          crash.artifactRef = reproducer.ref;
+        } else {
+          log(
+            `[userspace-fuzz] did not retain reproducer for ${crash.signature} ` +
+              "(missing, non-regular, changed while read, or exceeds the remaining evidence budget)",
+          );
+        }
+      }
+
+      const logRef = `${runDir}/logs/${id}.log`;
+      const logFile = writeBoundedUtf8File(
+        join(logsDir, `${id}.log`),
+        crash.rawOutput,
+        Math.min(MAX_RETAINED_LOG_BYTES, remaining),
+      );
+      if (logFile) remaining -= logFile.sizeBytes;
+
+      return {
+        signature: crash.signature,
+        kind: crash.kind,
+        primitive: crash.primitive ?? null,
+        stack: boundedStack(crash.stack),
+        log: logFile ? { ...logFile, ref: logRef } : null,
+        reproducer,
+      };
+    });
+
+  if (result.crashes.length > MAX_RETAINED_CRASHES) {
+    log(
+      `[userspace-fuzz] retained the first ${MAX_RETAINED_CRASHES} of ` +
+        `${result.crashes.length} deduplicated crashes`,
     );
-    if (retainedLogBytes > 0) {
-      const relativePath = `logs/${ordinal}-${crash.kind}.txt`;
-      writeRetainedBytes(
-        input.artifactDir,
-        relativePath,
-        logBytes.subarray(0, retainedLogBytes),
-      );
-      record.log = relativePath;
-      if (retainedLogBytes < logBytes.byteLength) {
-        record.log_truncated = true;
-      }
-      availableBytes -= retainedLogBytes;
-    } else if (logBytes.byteLength > 0) {
-      record.log_omitted = "artifact budget exhausted";
-    }
-
-    if (crash.inputPath) {
-      const relativePath = `reproducers/${ordinal}-${crash.signature}.input`;
-      const copied = copyRetainedInput(
-        crash.inputPath,
-        input.artifactDir,
-        relativePath,
-        availableBytes,
-      );
-      if ("bytes" in copied) {
-        crash.inputPath = join(input.artifactDir, relativePath);
-        record.reproducer = relativePath;
-        availableBytes -= copied.bytes;
-      } else {
-        crash.inputPath = undefined;
-        record.reproducer_omitted = copied.reason;
-      }
-    }
-    records.push(record);
   }
 
   const manifest = Buffer.from(
-    JSON.stringify({
-      schema: MEMSAFETY_ARTIFACT_SCHEMA,
-      run: input.run,
-      crashes: records,
-    }) + "\n",
+    JSON.stringify(
+      {
+        schema: MEMSAFETY_ARTIFACT_SCHEMA,
+        crashes,
+      },
+      null,
+      2,
+    ) + "\n",
     "utf8",
   );
-  if (manifest.byteLength > MANIFEST_RESERVE_BYTES) {
-    throw new Error("memsafety artifact manifest exceeds its reserved budget");
+  if (manifest.byteLength > ARTIFACT_MANIFEST_RESERVE_BYTES) {
+    rmSync(logsDir, { recursive: true, force: true });
+    rmSync(reproducersDir, { recursive: true, force: true });
+    log(
+      "[userspace-fuzz] evidence manifest exceeded its bounded reserve; discarded this run's retained copies",
+    );
+    return false;
   }
-  writeFileSync(join(input.artifactDir, "manifest.json"), manifest);
+  writeFileSync(join(workDir, "manifest.json"), manifest, {
+    flag: "wx",
+    mode: 0o600,
+  });
+  return true;
 }
 
-function copyRetainedInput(
-  sourcePath: string,
-  artifactDir: string,
-  relativePath: string,
-  availableBytes: number,
-): { bytes: number } | { reason: string } {
-  try {
-    const source = lstatSync(sourcePath);
-    if (!source.isFile()) {
-      return { reason: "source reproducer is not a regular file" };
-    }
-    if (source.size > availableBytes) {
-      return { reason: "source reproducer exceeds remaining artifact budget" };
-    }
-    const destination = join(artifactDir, relativePath);
-    mkdirSync(dirname(destination), { recursive: true });
-    copyFileSync(sourcePath, destination);
-    return { bytes: source.size };
-  } catch {
-    return { reason: "source reproducer was unavailable for retention" };
-  }
-}
-
-function writeRetainedBytes(
-  artifactDir: string,
-  relativePath: string,
-  contents: Uint8Array,
-): void {
-  const destination = join(artifactDir, relativePath);
-  mkdirSync(dirname(destination), { recursive: true });
-  writeFileSync(destination, contents);
-}
-
-function requireArtifactLimit(value: number | undefined): number {
-  const maxBytes = value ?? 8 * 1024 * 1024;
-  if (!Number.isSafeInteger(maxBytes) || maxBytes < MIN_ARTIFACT_BYTES) {
+function resolveRetainedArtifactBytes(value: number | undefined): number {
+  const bytes = value ?? DEFAULT_RETAINED_ARTIFACT_BYTES;
+  if (
+    !Number.isSafeInteger(bytes) ||
+    bytes < MIN_RETAINED_ARTIFACT_BYTES
+  ) {
     throw new Error(
-      `memsafety artifact byte ceiling must be at least ${MIN_ARTIFACT_BYTES}`,
+      `artifactMaxBytes must be a safe integer of at least ${MIN_RETAINED_ARTIFACT_BYTES}`,
     );
   }
-  return maxBytes;
+  return bytes;
 }
+
+function safeArtifactId(signature: string, index: number): string {
+  if (/^[0-9a-f]{16}$/.test(signature)) return signature;
+  return createHash("sha256")
+    .update(`${index}\0${signature}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+function boundedStack(stack: string[] | undefined): string[] {
+  return (stack ?? []).slice(0, 10).map((frame) => frame.slice(0, 1024));
+}
+
+function writeBoundedUtf8File(
+  path: string,
+  value: string,
+  limit: number,
+): Omit<ArtifactFile, "ref"> | null {
+  if (limit <= 0) return null;
+  const input = Buffer.from(value, "utf8");
+  const truncated = input.length > limit;
+  const bytes = truncated ? input.subarray(input.length - limit) : input;
+  writeFileSync(path, bytes, { flag: "wx", mode: 0o600 });
+  return {
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    sizeBytes: bytes.length,
+    ...(truncated ? { truncated: true } : {}),
+  };
+}
+
+function copyBoundedReproducer(
+  source: string,
+  destination: string,
+  ref: string,
+  sourceRoot: string,
+  limit: number,
+): ArtifactFile | null {
+  let fd: number | undefined;
+  try {
+    if (!isStableSourceDirectory(sourceRoot, dirname(source))) {
+      return null;
+    }
+    const listed = lstatSync(source);
+    if (
+      !listed.isFile() ||
+      listed.isSymbolicLink() ||
+      listed.size > limit
+    ) {
+      return null;
+    }
+    fd = openSync(source, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    const before = fstatSync(fd);
+    if (
+      !before.isFile() ||
+      before.dev !== listed.dev ||
+      before.ino !== listed.ino ||
+      before.size !== listed.size ||
+      before.mtimeMs !== listed.mtimeMs
+    ) {
+      return null;
+    }
+    const bytes = readFileSync(fd);
+    const after = fstatSync(fd);
+    if (
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.size !== after.size ||
+      before.mtimeMs !== after.mtimeMs ||
+      bytes.length !== before.size
+    ) {
+      return null;
+    }
+    if (!isStableSourceDirectory(sourceRoot, dirname(source))) {
+      return null;
+    }
+    writeFileSync(destination, bytes, { flag: "wx", mode: 0o600 });
+    return {
+      ref,
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      sizeBytes: bytes.length,
+    };
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
 
 interface LoopCtx {
   workDir: string;
@@ -682,11 +827,12 @@ async function runRustLoop(
 ): Promise<FuzzLoopResult> {
   const { target } = opts;
   const sourceRoot = resolve(target.sourceRoot);
-  const fuzzBase = target.fuzzDir ?? "fuzz";
+  const fuzzRoot = resolveCargoFuzzDir(sourceRoot, target.fuzzDir);
   const crashes: CrashArtifact[] = [];
   let iterations = 0;
   let harnessEntry = target.harnessEntry;
   let executedHarness: string | undefined;
+
 
   // cargo is the floor requirement for any Rust path.
   if (!(await cargoAvailable())) {
@@ -694,6 +840,13 @@ async function runRustLoop(
     ctx.log(`[userspace-fuzz] ${TOOLING_HINTS.cargo}`);
     return finish(crashes, iterations, sourceRoot, ctx, "fuzz");
   }
+
+  if (!fuzzRoot || (harnessEntry && !isCargoFuzzHarnessName(harnessEntry))) {
+    ctx.toolingMissing.push("cargo-fuzz-layout");
+    ctx.log("[userspace-fuzz] rejected unsafe cargo-fuzz directory or harness name");
+    return finish(crashes, iterations, sourceRoot, ctx, "fuzz");
+  }
+  const fuzzDir = relative(sourceRoot, fuzzRoot);
 
   // ── cargo-fuzz (libFuzzer) ─────────────────────────────────────────
   if (!(await cargoFuzzAvailable())) {
@@ -703,7 +856,7 @@ async function runRustLoop(
     if (!harnessEntry) {
       const discovery = await discoverCargoFuzzHarness(
         sourceRoot,
-        target.fuzzDir,
+        fuzzDir,
         ctx.timeoutMs,
       );
       if ("reason" in discovery) {
@@ -713,7 +866,13 @@ async function runRustLoop(
         );
       } else {
         harnessEntry = discovery.harnessEntry;
-        ctx.log(`[userspace-fuzz] auto-selected cargo-fuzz harness ${harnessEntry}`);
+        if (!isCargoFuzzHarnessName(harnessEntry)) {
+          ctx.toolingMissing.push("cargo-fuzz-harness");
+          ctx.log("[userspace-fuzz] cargo-fuzz reported an unsafe harness name");
+          harnessEntry = undefined;
+        } else {
+          ctx.log(`[userspace-fuzz] auto-selected cargo-fuzz harness ${harnessEntry}`);
+        }
       }
     }
 
@@ -721,7 +880,7 @@ async function runRustLoop(
       ctx.log(`[userspace-fuzz] cargo fuzz run ${harnessEntry} (<=${ctx.timeoutMs / 1000}s)`);
       const res = await runChild(
         "cargo",
-        cargoFuzzRunArgs(harnessEntry, target.fuzzDir, ctx.timeoutMs / 1000),
+        cargoFuzzRunArgs(harnessEntry, fuzzDir, ctx.timeoutMs / 1000),
         sourceRoot,
         ctx.timeoutMs + 30_000, // grace beyond libFuzzer's own budget
       );
@@ -730,7 +889,8 @@ async function runRustLoop(
       const crash = parseCrashOutput(res.output, {
         kind: res.timedOut ? "timeout" : undefined,
         inputPath: findLibfuzzerCrashInput(
-          join(sourceRoot, fuzzBase, "artifacts", harnessEntry),
+          join(fuzzRoot, "artifacts", harnessEntry),
+          sourceRoot,
         ),
       });
       if (crash) crashes.push(crash);
@@ -760,8 +920,8 @@ async function runRustLoop(
 
   // cargo-fuzz stores its corpus under <fuzzDir>/corpus/<target> (default `fuzz`).
   const corpusDir = harnessEntry
-    ? join(sourceRoot, fuzzBase, "corpus", harnessEntry)
-    : join(sourceRoot, fuzzBase, "corpus");
+    ? join(fuzzRoot, "corpus", harnessEntry)
+    : join(fuzzRoot, "corpus");
   const result = finishWithCorpus(crashes, iterations, corpusDir, ctx);
   if (executedHarness) result.executedHarness = executedHarness;
   return result;
@@ -815,7 +975,7 @@ async function runCLoop(
   });
   if (crash) {
     // libFuzzer writes the reproducing input as `crash-<sha1>` in cwd.
-    crash.inputPath = findLibfuzzerCrashInput(sourceRoot) ?? crash.inputPath;
+    crash.inputPath = findLibfuzzerCrashInput(sourceRoot, sourceRoot) ?? crash.inputPath;
     crashes.push(crash);
   }
 
@@ -823,12 +983,21 @@ async function runCLoop(
 }
 
 /** libFuzzer drops `crash-*` / `oom-*` / `timeout-*` reproducers in cwd. */
-function findLibfuzzerCrashInput(dir: string): string | undefined {
+function findLibfuzzerCrashInput(
+  dir: string,
+  sourceRoot: string,
+): string | undefined {
+  if (!isStableSourceDirectory(sourceRoot, dir)) return undefined;
   try {
     const hit = readdirSync(dir).find((name) =>
       /^(crash|oom|timeout|leak)-[0-9a-f]+$/i.test(name),
     );
-    return hit ? join(dir, hit) : undefined;
+    if (!hit || !isStableSourceDirectory(sourceRoot, dir)) return undefined;
+    const candidate = join(dir, hit);
+    const listed = lstatSync(candidate);
+    return listed.isFile() && !listed.isSymbolicLink()
+      ? candidate
+      : undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
Migrates the reviewed retained-artifact hardening from the preserved private worktree snapshot onto the current public `main` baseline.\n\nThe retained evidence path now uses canonical source roots, rejects symlink and traversal escape, copies bounded regular-file reproducers with TOCTOU checks, bounds logs and manifests under an aggregate budget, and removes no-crash persistent run directories. Existing CLI forwarding coverage is retained alongside the new containment tests.\n\nValidated: `pnpm --filter @pwnkit/core exec vitest run src/triage/userspace-fuzz-runner.test.ts`; `pnpm --filter pwnkit-cli exec vitest run src/commands/__tests__/memsafety.test.ts`; `pnpm --filter @pwnkit/core build`; `pnpm --filter @pwnkit/benchmark build`; `pnpm --filter pwnkit-cli build`.