### PR TITLE
feat(public): port finding provenance

### DIFF
--- a/docs/src/content/docs/triage.md
+++ b/docs/src/content/docs/triage.md
@@ -276,15 +276,100 @@ a known lead.
 
 | Env var | Default | Stage |
 |---------|---------|-------|
+| `PWNKIT_FEATURE_HOLDING_IT_WRONG` | **on** | 1 |
+| `PWNKIT_FEATURE_EVIDENCE_GATE` | **on** | 2 |
 | `PWNKIT_FEATURE_REACHABILITY_GATE` | off | 4 |
 | `PWNKIT_FEATURE_MULTIMODAL` | off | 5 |
 | `PWNKIT_FEATURE_POV_GATE` | off | 6 |
+| `PWNKIT_FEATURE_PUBLISHABILITY_GATE` | off | 6 |
+| `PWNKIT_FEATURE_POC_GEN_STATIC` | off | 6 |
 | `PWNKIT_FEATURE_CONSENSUS_VERIFY` | off | 8 |
-| `PWNKIT_FEATURE_TRIAGE_MEMORIES` | off | 9 |
-| `PWNKIT_FEATURE_DEBATE` | off | 10 |
-| `PWNKIT_FEATURE_EGATS` | off | 11 |
+| `PWNKIT_FEATURE_LEARNED_ROUTER` | off | router |
+| `PWNKIT_FEATURE_DYNAMIC_TRIAGE` | off | router |
+
+`PWNKIT_FEATURE_TRIAGE_MEMORIES`, `PWNKIT_FEATURE_DEBATE`, and
+`PWNKIT_FEATURE_EGATS` appeared in earlier versions of this table but no
+longer exist in the codebase — `egats` was removed from the default
+aliases after the ablation measured it regressing the hardest slice
+([pwnkit#116](https://github.com/0sec-labs/pwnkit/issues/116)). Sections
+9-11 above describe layers that are no longer separately toggleable.
 
 See [Features](/features/) for the complete env-var inventory.
+
+## Enabling the whole moat at once
+
+Turning the moat on is a measurement, not an upgrade. The
+[2026-04-11 ablation](/research/2026-04-11-ablation/) found its effect is
+slice-dependent: a strict win on XBOW black-box, a 0-2 flag cost on
+white-box (inside run noise after the broken `egats` layer was removed),
+and a no-op on npm-bench. The large number people remember — roughly 60%
+fewer findings — is the moat working as intended; the flag count, which
+is the ground-truth-correct outcome, stayed roughly flat. Enable it to
+re-measure, not because it is expected to score better.
+
+Every gate above is off by default, so measuring what the moat is worth
+means setting six variables and getting all six right. `fp-moat` is a
+preset that names the set:
+
+```bash
+pwnkit scan --features fp-moat --target https://example.com
+# or, for CI where the command line is templated:
+PWNKIT_FEATURE_PRESET=fp-moat pwnkit scan --target https://example.com
+```
+
+It expands to `PWNKIT_FEATURE_REACHABILITY_GATE`, `_MULTIMODAL`,
+`_PUBLISHABILITY_GATE`, `_POV_GATE`, `_POC_GEN_STATIC`, and
+`_CONSENSUS_VERIFY`. The membership lives in
+`packages/core/src/agent/feature-presets.ts` and is pinned by test.
+
+A flag you set yourself always wins, so you can ablate one layer out of
+an otherwise-full moat:
+
+```bash
+PWNKIT_FEATURE_POV_GATE=0 pwnkit scan --features fp-moat …
+```
+
+The preset deliberately leaves out `PWNKIT_FEATURE_LEARNED_ROUTER` and
+`PWNKIT_FEATURE_DYNAMIC_TRIAGE`. Those decide which layers to *skip* per
+finding, so enabling them alongside the moat would let the router
+suppress the layers you are trying to measure.
+
+## Checking which layers actually ran
+
+Turning layers on is only half of a defensible claim. Each layer records
+a verdict on the finding as it executes, and `findings show` renders that
+record:
+
+```bash
+pwnkit findings show <id>
+```
+
+```
+  Triage provenance:
+  FP moat NOT engaged: no opt-in moat layer ran for this finding (always-on filters only)
+  Layers: 3 executed, 5 skipped, 3 unrecorded | 412ms | $0.0000
+    + holding_it_wrong   executed(pass) — no holding-it-wrong pattern matched
+    + evidence_gate      executed(pass) — evidence_completeness=0.83 > 0.5
+    - reachability       skipped(skip) — PWNKIT_FEATURE_REACHABILITY_GATE=0
+    …
+```
+
+Three things worth knowing about how to read this:
+
+- It is derived from the verdicts stored **on the finding**, never from
+  your current environment. A finding produced by a default scan still
+  reports the moat as not engaged even if you have every flag exported in
+  your shell — otherwise re-reading an old finding could silently
+  overstate what it went through.
+- `skipped` and `unrecorded` are different. `skipped` means the layer
+  recorded that it stood down, and the reason names the flag or the
+  missing precondition. `unrecorded` means no verdict exists at all.
+- Three layers are permanently `unrecorded`: `structured_verify`,
+  `consensus`, and `kernel_oracle` emit no verdict anywhere in the
+  engine, so their execution cannot be observed today. They are listed in
+  `UNINSTRUMENTED_LAYERS` and reported with an explicit
+  "no instrumentation" reason rather than being quietly counted as
+  skipped. Until that changes, they cannot back an FP-moat claim.
 
 ## Further reading
 

--- a/packages/cli/src/commands/__tests__/feature-preset-tokens.test.ts
+++ b/packages/cli/src/commands/__tests__/feature-preset-tokens.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Anti-drift pin between the CLI's preset-token set and core's resolver.
+ *
+ * `scan.ts` recognises preset tokens from a local literal so it does not have
+ * to import core just to parse `--features`. That duplication is safe only if
+ * both sides agree, and the failure mode if they don't is silent: an
+ * unrecognised token becomes a meaningless `PWNKIT_FEATURE_*` var and enables
+ * nothing, while the run still succeeds and reports findings. This test makes
+ * that divergence loud.
+ *
+ * Deliberately does NOT mock `@pwnkit/core` — the point is to check the CLI
+ * against the real resolver.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveFeaturePreset, FEATURE_PRESETS } from "@pwnkit/core";
+import { PRESET_TOKENS } from "../scan.js";
+
+describe("CLI preset tokens match core's resolver", () => {
+  it("every CLI preset token resolves to a real preset in core", () => {
+    for (const token of PRESET_TOKENS) {
+      const resolved = resolveFeaturePreset(token);
+      expect(resolved, `token '${token}' does not resolve in core`).toBeDefined();
+      expect(FEATURE_PRESETS[resolved!]).toBeDefined();
+    }
+  });
+
+  it("covers the fp-moat preset, the one the docs tell operators to use", () => {
+    expect(PRESET_TOKENS.has("fp-moat")).toBe(true);
+    expect(resolveFeaturePreset("fp-moat")).toBe("fp-moat");
+  });
+
+  it("does not claim ordinary feature flags as presets", () => {
+    expect(PRESET_TOKENS.has("wp_fingerprint")).toBe(false);
+    expect(PRESET_TOKENS.has("web_search")).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/findings.ts
+++ b/packages/cli/src/commands/findings.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import chalk from "chalk";
-import type { FindingTriageStatus } from "@pwnkit/shared";
+import type { Finding, FindingTriageStatus, LayerVerdict } from "@pwnkit/shared";
 
 type FindingsListOptions = {
   dbPath?: string;
@@ -30,7 +30,33 @@ type FindingRow = {
   evidenceRequest: string;
   evidenceResponse: string;
   evidenceAnalysis?: string | null;
+  /**
+   * JSON-encoded `LayerVerdict[]` as persisted by the scanner. Nullable and
+   * possibly malformed — it is a TEXT column written across engine versions,
+   * so `parseLayerVerdicts` treats any parse failure as "no record" rather
+   * than throwing in a display path.
+   */
+  layerVerdicts?: string | null;
 };
+
+/**
+ * Decode the persisted `layerVerdicts` column into the array shape
+ * `summarizeTriageProvenance` expects.
+ *
+ * Intentionally lenient: this feeds a read-only display, and a finding whose
+ * verdict blob is unreadable should still render its evidence. A decode
+ * failure yields `[]`, which provenance reports as every layer `unrecorded` —
+ * the honest answer, and never a claim that a layer ran.
+ */
+function parseLayerVerdicts(raw: string | null | undefined): LayerVerdict[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as LayerVerdict[]) : [];
+  } catch {
+    return [];
+  }
+}
 
 function resolveFindingsOptions(opts: FindingsListOptions, command?: Command): FindingsListOptions {
   const inherited = command?.parent && typeof command.parent.opts === "function"
@@ -320,6 +346,33 @@ export function registerFindingsCommand(program: Command): void {
           console.log(`  ${chalk.gray("Evidence \u2014 Analysis:")}`);
           console.log(`  ${chalk.dim(finding.evidenceAnalysis)}`);
         }
+        // ── Triage provenance ──
+        // The answer to "which FP-moat layers actually ran for this finding?".
+        // Rendered for EVERY finding, including ones where nothing ran: an
+        // absent section would read as "not applicable" when the truthful
+        // reading is "the moat did not run". Derived purely from the recorded
+        // verdicts, so it reflects the scan's configuration and not this
+        // shell's env — see `triage/provenance.ts`.
+        {
+          const { summarizeTriageProvenance, formatTriageProvenance } = await import(
+            "@pwnkit/core"
+          );
+          const provenance = summarizeTriageProvenance({
+            ...(finding as unknown as Finding),
+            layerVerdicts: parseLayerVerdicts(finding.layerVerdicts),
+          });
+          const [headline, totals, ...layerLines] = formatTriageProvenance(provenance);
+          console.log("");
+          console.log(`  ${chalk.gray("Triage provenance:")}`);
+          console.log(
+            `  ${provenance.moatEngaged ? chalk.green(headline) : chalk.yellow(headline)}`,
+          );
+          console.log(`  ${chalk.gray(totals)}`);
+          for (const line of layerLines) {
+            console.log(`  ${chalk.dim(line)}`);
+          }
+        }
+
         if (related.length > 1) {
           console.log("");
           console.log(`  ${chalk.gray("Related Findings:")}`);

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -134,6 +134,24 @@ function validateEmitTarget(value: string | undefined): "pr" | undefined {
   process.exit(2);
 }
 
+/**
+ * `--features` tokens that name a PRESET rather than a single flag.
+ *
+ * Kept as a literal here on purpose: this handler must not import
+ * `@pwnkit/core` just to recognise a token, since core is loaded lazily so
+ * `--help` stays fast. The authoritative expansion still lives in core — this
+ * set only decides *which* tokens get forwarded as `PWNKIT_FEATURE_PRESET`.
+ *
+ * `feature-preset-tokens.test.ts` asserts every entry here resolves to a real
+ * preset in core, so the two cannot drift apart silently.
+ */
+export const PRESET_TOKENS: ReadonlySet<string> = new Set([
+  "fp-moat",
+  "fp_moat",
+  "fpmoat",
+  "moat",
+]);
+
 export function registerScanCommand(program: Command): void {
   program
     .command("scan")
@@ -181,7 +199,7 @@ export function registerScanCommand(program: Command): void {
     .option("--tui", "Open the local terminal UI after the scan completes", false)
     .option(
       "--features <list>",
-      "Comma-separated list of opt-in feature flags to enable for this scan (e.g. 'wp_fingerprint,web_search'). Each flag maps to the corresponding PWNKIT_FEATURE_<NAME> environment variable.",
+      "Comma-separated list of opt-in feature flags to enable for this scan (e.g. 'wp_fingerprint,web_search'). Each flag maps to the corresponding PWNKIT_FEATURE_<NAME> environment variable. The token 'fp-moat' is a preset that enables the full false-positive moat (reachability, multi-modal, publishability, pov-gate, poc-gen, consensus) for an A/B run; an env var you set yourself always wins over the preset, so 'PWNKIT_FEATURE_POV_GATE=0 --features fp-moat' is a single-layer ablation.",
     )
     .option(
       "--no-decoy-detection",
@@ -303,12 +321,30 @@ export function registerScanCommand(program: Command): void {
       // your shell. Flags that are declared as getters (e.g. wp_fingerprint)
       // re-read the env at access time and therefore honor this flag even
       // though it's applied inside the action handler.
+      //
+      // A token that names a PRESET (e.g. `fp-moat`) expands to that preset's
+      // whole flag set instead of becoming a single env var. Without this, the
+      // token would silently set the meaningless `PWNKIT_FEATURE_FP_MOAT` and
+      // enable nothing — a failure mode that looks like success, which is the
+      // worst possible one for a flag whose entire purpose is enabling an A/B.
+      //
+      // A preset token sets `PWNKIT_FEATURE_PRESET` instead of a single flag.
+      // The expansion itself lives in core (`agent/features.ts` consults the
+      // preset when a flag's own var is unset), so every entry point honours
+      // it — this handler only has to forward the name. Without this branch
+      // the token would set the meaningless `PWNKIT_FEATURE_FP_MOAT` and
+      // enable nothing: a failure that looks like success, which is the worst
+      // outcome for a flag whose only purpose is enabling an A/B.
       if (opts.features) {
         const tokens = String(opts.features)
           .split(",")
           .map((t) => t.trim())
           .filter(Boolean);
         for (const token of tokens) {
+          if (PRESET_TOKENS.has(token.toLowerCase())) {
+            process.env.PWNKIT_FEATURE_PRESET = token.toLowerCase();
+            continue;
+          }
           const envName = `PWNKIT_FEATURE_${token.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
           process.env[envName] = "1";
         }

--- a/packages/core/src/agent/feature-presets.test.ts
+++ b/packages/core/src/agent/feature-presets.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  FEATURE_PRESETS,
+  applyFeaturePreset,
+  applyFeaturePresetFromEnv,
+  resolveFeaturePreset,
+} from "./feature-presets.js";
+import { features } from "./features.js";
+
+describe("feature presets — fp-moat membership", () => {
+  /**
+   * Pins the exact flag set. This is the whole value of the preset: an A/B
+   * result is only citable if the enabled set is written down and stable, so a
+   * change to membership must be a deliberate, reviewed diff rather than an
+   * incidental edit.
+   */
+  it("enables exactly the six opt-in FP-moat flags", () => {
+    expect([...FEATURE_PRESETS["fp-moat"]].sort()).toEqual([
+      "PWNKIT_FEATURE_CONSENSUS_VERIFY",
+      "PWNKIT_FEATURE_MULTIMODAL",
+      "PWNKIT_FEATURE_POC_GEN_STATIC",
+      "PWNKIT_FEATURE_POV_GATE",
+      "PWNKIT_FEATURE_PUBLISHABILITY_GATE",
+      "PWNKIT_FEATURE_REACHABILITY_GATE",
+    ]);
+  });
+
+  /**
+   * The routers decide which layers to SKIP. Enabling them inside the moat
+   * preset would let the router suppress the very layers the A/B measures, so
+   * their absence is a correctness property, not an omission.
+   */
+  it("excludes the triage routers and inline validation", () => {
+    const flags = FEATURE_PRESETS["fp-moat"];
+    expect(flags).not.toContain("PWNKIT_FEATURE_LEARNED_ROUTER");
+    expect(flags).not.toContain("PWNKIT_FEATURE_DYNAMIC_TRIAGE");
+    expect(flags).not.toContain("PWNKIT_FEATURE_INLINE_VALIDATION");
+  });
+
+  /** The always-on filters already run; including them would overstate the preset. */
+  it("excludes the always-on filters", () => {
+    const flags = FEATURE_PRESETS["fp-moat"];
+    expect(flags).not.toContain("PWNKIT_FEATURE_HOLDING_IT_WRONG");
+    expect(flags).not.toContain("PWNKIT_FEATURE_EVIDENCE_GATE");
+  });
+
+  /**
+   * `egats` is the one layer our own ablation measured as genuinely broken
+   * (2 -> 1 flags at 10x the worst per-flag cost on stubborn-14; removed from
+   * the default aliases in pwnkit#116). Its flag no longer exists in the
+   * codebase, and the preset must never resurrect it — an A/B arm containing a
+   * known-regressing layer would invalidate the comparison.
+   */
+  it("never enables the measured-broken egats layer", () => {
+    for (const flag of FEATURE_PRESETS["fp-moat"]) {
+      expect(flag).not.toMatch(/EGATS/i);
+    }
+  });
+});
+
+describe("feature presets — application", () => {
+  it("sets every flag to '1' on a clean env", () => {
+    const env: NodeJS.ProcessEnv = {};
+    const result = applyFeaturePreset("fp-moat", env);
+
+    expect(result.applied).toHaveLength(6);
+    expect(result.preserved).toHaveLength(0);
+    for (const flag of FEATURE_PRESETS["fp-moat"]) {
+      expect(env[flag]).toBe("1");
+    }
+  });
+
+  /**
+   * The per-layer ablation guarantee. An operator disabling one layer while
+   * running the preset must get "moat minus that layer" — if the preset
+   * overrode them, attributing an effect to a single layer would be
+   * impossible.
+   */
+  it("never overwrites an explicitly-set flag, including '0'", () => {
+    const env: NodeJS.ProcessEnv = { PWNKIT_FEATURE_POV_GATE: "0" };
+    const result = applyFeaturePreset("fp-moat", env);
+
+    expect(env.PWNKIT_FEATURE_POV_GATE).toBe("0");
+    expect(result.preserved).toEqual(["PWNKIT_FEATURE_POV_GATE"]);
+    expect(result.applied).not.toContain("PWNKIT_FEATURE_POV_GATE");
+    // Every other layer still came on.
+    expect(env.PWNKIT_FEATURE_REACHABILITY_GATE).toBe("1");
+    expect(result.applied).toHaveLength(5);
+  });
+
+  it("is idempotent — a second application changes nothing", () => {
+    const env: NodeJS.ProcessEnv = {};
+    applyFeaturePreset("fp-moat", env);
+    const second = applyFeaturePreset("fp-moat", env);
+
+    expect(second.applied).toHaveLength(0);
+    expect(second.preserved).toHaveLength(6);
+  });
+
+  it("does not touch flags outside the preset", () => {
+    const env: NodeJS.ProcessEnv = {};
+    applyFeaturePreset("fp-moat", env);
+    expect(env.PWNKIT_FEATURE_WEB_SEARCH).toBeUndefined();
+    expect(env.PWNKIT_FEATURE_DYNAMIC_TRIAGE).toBeUndefined();
+  });
+});
+
+describe("feature presets — token resolution", () => {
+  it("accepts hyphen, underscore, bare and short spellings", () => {
+    for (const token of ["fp-moat", "fp_moat", "fpmoat", "moat", "FP-MOAT", " Moat "]) {
+      expect(resolveFeaturePreset(token)).toBe("fp-moat");
+    }
+  });
+
+  it("returns undefined for a non-preset token so it falls through to a plain flag", () => {
+    expect(resolveFeaturePreset("wp_fingerprint")).toBeUndefined();
+    expect(resolveFeaturePreset("")).toBeUndefined();
+  });
+});
+
+describe("PWNKIT_FEATURE_PRESET is honoured by the feature flags themselves", () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  /**
+   * The whole-engine wiring. Setting one variable must flip the moat flags for
+   * ANY entry point that reads `features.*` — not just the CLI. If this
+   * regresses, a CI A/B run would silently measure the default arm twice.
+   */
+  it("turns on every moat layer from the single preset variable", () => {
+    expect(features.povGate).toBe(false);
+    expect(features.reachabilityGate).toBe(false);
+
+    process.env.PWNKIT_FEATURE_PRESET = "fp-moat";
+
+    expect(features.povGate).toBe(true);
+    expect(features.reachabilityGate).toBe(true);
+    expect(features.multiModalAgreement).toBe(true);
+    expect(features.publishabilityGate).toBe(true);
+    expect(features.pocGenStatic).toBe(true);
+    expect(features.selfConsistencyVerify).toBe(true);
+  });
+
+  /** An explicit `0` beats the preset — this is the per-layer ablation path. */
+  it("lets an explicit flag override the preset in both directions", () => {
+    process.env.PWNKIT_FEATURE_PRESET = "fp-moat";
+    process.env.PWNKIT_FEATURE_POV_GATE = "0";
+
+    expect(features.povGate).toBe(false);
+    expect(features.reachabilityGate).toBe(true);
+  });
+
+  it("leaves flags outside the preset at their own defaults", () => {
+    process.env.PWNKIT_FEATURE_PRESET = "fp-moat";
+
+    // Routers are excluded so they cannot skip the layers being measured.
+    expect(features.learnedRouter).toBe(false);
+    expect(features.dynamicTriageRouting).toBe(false);
+    expect(features.inlineValidation).toBe(false);
+    // Unrelated experimental flags are untouched.
+    expect(features.webSearch).toBe(false);
+    // Always-on flags stay on.
+    expect(features.holdingItWrong).toBe(true);
+  });
+
+  it("ignores an unrecognized preset name rather than failing the scan", () => {
+    process.env.PWNKIT_FEATURE_PRESET = "not-a-preset";
+    expect(features.povGate).toBe(false);
+    expect(features.holdingItWrong).toBe(true);
+  });
+});
+
+describe("feature presets — env-driven application", () => {
+  it("applies the preset named by PWNKIT_FEATURE_PRESET", () => {
+    const env: NodeJS.ProcessEnv = { PWNKIT_FEATURE_PRESET: "fp-moat" };
+    const result = applyFeaturePresetFromEnv(env);
+
+    expect(result?.preset).toBe("fp-moat");
+    expect(env.PWNKIT_FEATURE_POV_GATE).toBe("1");
+  });
+
+  /**
+   * A stale or misspelled CI variable degrades to default behaviour rather
+   * than failing the run — a scan that still produces findings under the
+   * documented default is strictly better than a hard stop.
+   */
+  it("ignores an unset or unrecognized preset name without throwing", () => {
+    expect(applyFeaturePresetFromEnv({})).toBeUndefined();
+
+    const env: NodeJS.ProcessEnv = { PWNKIT_FEATURE_PRESET: "not-a-preset" };
+    expect(applyFeaturePresetFromEnv(env)).toBeUndefined();
+    expect(env.PWNKIT_FEATURE_POV_GATE).toBeUndefined();
+  });
+});

--- a/packages/core/src/agent/feature-presets.ts
+++ b/packages/core/src/agent/feature-presets.ts
@@ -1,0 +1,172 @@
+/**
+ * Feature presets — named bundles of `PWNKIT_FEATURE_*` env vars.
+ *
+ * ## Why this exists
+ *
+ * `agent/features.ts` states the blocker plainly: the v0.6.0 FP-moat layers
+ * "need explicit enablement in CI before any FP-moat A/B claim can be made."
+ * Every one of those layers is default-OFF and gated behind its own env var,
+ * so "enable the moat" currently means setting seven separate variables and
+ * getting all seven right. Nothing in the repo names the full set, which makes
+ * an A/B run something you reconstruct by reading source each time — and
+ * therefore something that is easy to get subtly wrong and impossible to cite.
+ *
+ * A preset makes the set a single named, reviewable, testable object. That is
+ * the point: not to turn the moat on, but to make turning it on reproducible
+ * enough that the resulting measurement means something.
+ *
+ * ## What this is NOT
+ *
+ * Applying a preset is not a claim that these layers help. We have measured
+ * this once already — the 2026-04-11 ablation
+ * (`docs/src/content/docs/research/2026-04-11-ablation.md`, 21 profiles) — and
+ * the result was slice-dependent, not a win:
+ *
+ *   - XBOW white-box: the moat cost 0-2 flags for ~60% fewer findings. Batch 2
+ *     put the flag gap inside run-to-run noise at N=50.
+ *   - XBOW black-box: the moat strictly dominated — MORE flags (19 vs 18),
+ *     fewer findings, and cheaper per flag.
+ *   - npm-bench: a no-op. The batch-1 FPR attribution was retracted in batch 2
+ *     as a ~2-package noise swing.
+ *
+ * Read that carefully, because the headline is easy to garble: the large drop
+ * is in FINDINGS, which is the moat doing its job, while the FLAG count (the
+ * ground-truth-correct outcome) stayed roughly flat. "Fewer findings" is the
+ * intended effect, not the regression.
+ *
+ * Exactly one layer was measured as genuinely broken: `egats` tree search went
+ * 2 → 1 flags at 10× the worst per-flag cost on stubborn-14, and was removed
+ * from the default aliases (pwnkit#116). Its flag no longer exists in this
+ * codebase, so it cannot reappear through this preset.
+ *
+ * The preset exists so that measurement can be REPEATED — the profile aliases
+ * the 2026-04-11 run used (`moat`, `moat-only`, `no-triage`, `none`) are gone
+ * from the repo and from CI, which is why re-running the A/B currently means
+ * reconstructing the flag set by reading source. That is the gap this closes.
+ *
+ * ## Precedence: an explicit env var always wins
+ *
+ * {@link applyFeaturePreset} never overwrites a variable that is already set.
+ * An operator running `PWNKIT_FEATURE_POV_GATE=0` with the moat preset gets
+ * the moat minus the PoV gate — which is exactly the single-layer ablation you
+ * need to attribute an effect to one layer. Silently overriding the operator
+ * would make per-layer ablation impossible, so the precedence is deliberate.
+ *
+ * Usage:
+ *   PWNKIT_FEATURE_PRESET=fp-moat pwnkit scan …
+ *   pwnkit scan --features fp-moat …
+ */
+
+/** Names of the presets this module knows how to apply. */
+export type FeaturePresetName = "fp-moat";
+
+/**
+ * The full opt-in false-positive moat.
+ *
+ * Every entry is a layer that `agent/features.ts` documents as default-OFF and
+ * requiring explicit enablement before an A/B claim. The always-on filters
+ * (`holding_it_wrong`, `evidence_gate`) and the unconditional `oracle` layer
+ * are absent on purpose — they already run, so including them would imply the
+ * preset changes something it does not.
+ *
+ * Deliberately excluded despite being FP-adjacent:
+ *   - `PWNKIT_FEATURE_LEARNED_ROUTER` and `PWNKIT_FEATURE_DYNAMIC_TRIAGE` —
+ *     these ROUTE layers (they decide which layers to skip per finding).
+ *     Turning them on alongside the moat would let the router suppress the
+ *     very layers the A/B is trying to measure, confounding the result. They
+ *     are separately measurable and belong in their own preset.
+ *   - `PWNKIT_FEATURE_INLINE_VALIDATION` — it runs inside the attack loop and
+ *     changes EGATS scoring, so it alters discovery as well as triage. Mixing
+ *     a discovery-side change into a triage A/B would make the arms
+ *     non-comparable.
+ */
+const FP_MOAT_FLAGS: readonly string[] = [
+  "PWNKIT_FEATURE_REACHABILITY_GATE",
+  "PWNKIT_FEATURE_MULTIMODAL",
+  "PWNKIT_FEATURE_PUBLISHABILITY_GATE",
+  "PWNKIT_FEATURE_POV_GATE",
+  "PWNKIT_FEATURE_POC_GEN_STATIC",
+  "PWNKIT_FEATURE_CONSENSUS_VERIFY",
+] as const;
+
+/** Every preset, by name. */
+export const FEATURE_PRESETS: Readonly<Record<FeaturePresetName, readonly string[]>> =
+  Object.freeze({
+    "fp-moat": FP_MOAT_FLAGS,
+  });
+
+/** Tokens accepted as preset names, including hyphen/underscore spellings. */
+const PRESET_ALIASES: Readonly<Record<string, FeaturePresetName>> = Object.freeze({
+  "fp-moat": "fp-moat",
+  fp_moat: "fp-moat",
+  fpmoat: "fp-moat",
+  moat: "fp-moat",
+});
+
+/**
+ * Resolve a user-supplied token to a preset name, or `undefined` when the
+ * token is not a preset. Case- and separator-insensitive so `--features MOAT`
+ * and `--features fp_moat` both work.
+ */
+export function resolveFeaturePreset(token: string): FeaturePresetName | undefined {
+  return PRESET_ALIASES[token.trim().toLowerCase()];
+}
+
+/** What {@link applyFeaturePreset} did, for logging and for tests. */
+export interface PresetApplication {
+  preset: FeaturePresetName;
+  /** Vars this call set to "1". */
+  applied: readonly string[];
+  /**
+   * Vars left alone because they were already set. Their existing value wins —
+   * this is the per-layer ablation escape hatch described in the module header.
+   */
+  preserved: readonly string[];
+}
+
+/**
+ * Apply a preset by setting each of its env vars to "1", skipping any var that
+ * is already set to anything (including "0").
+ *
+ * `env` is injectable so tests can assert against a plain object rather than
+ * mutating the real process environment.
+ *
+ * Timing note: every flag in `agent/features.ts` is a getter that reads
+ * `process.env` at access time, so applying a preset inside a CLI action
+ * handler — after the module graph has loaded — is still honoured. That is why
+ * this can be wired into command setup rather than requiring a shell export.
+ */
+export function applyFeaturePreset(
+  preset: FeaturePresetName,
+  env: NodeJS.ProcessEnv = process.env,
+): PresetApplication {
+  const applied: string[] = [];
+  const preserved: string[] = [];
+
+  for (const flag of FEATURE_PRESETS[preset]) {
+    if (env[flag] !== undefined) {
+      preserved.push(flag);
+      continue;
+    }
+    env[flag] = "1";
+    applied.push(flag);
+  }
+
+  return { preset, applied, preserved };
+}
+
+/**
+ * Apply the preset named by `PWNKIT_FEATURE_PRESET`, if any. Returns
+ * `undefined` when the variable is unset or names something unrecognized —
+ * an unknown preset is ignored rather than fatal so a stale CI variable
+ * degrades to default behaviour instead of failing the run.
+ */
+export function applyFeaturePresetFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): PresetApplication | undefined {
+  const raw = env.PWNKIT_FEATURE_PRESET;
+  if (!raw) return undefined;
+  const preset = resolveFeaturePreset(raw);
+  if (!preset) return undefined;
+  return applyFeaturePreset(preset, env);
+}

--- a/packages/core/src/agent/features.ts
+++ b/packages/core/src/agent/features.ts
@@ -12,7 +12,32 @@
  *   - "always-on triage filters" (`holdingItWrong`, `evidenceGate`) default
  *     ON — they're the only filters that ran in every v0.6.0 ablation, so
  *     they need to be ablatable.
+ *
+ * ## Enabling the full FP moat for an A/B
+ *
+ * The "explicit enablement" noted above now has one documented form, so an
+ * A/B run does not depend on reconstructing the flag set by reading source:
+ *
+ *   PWNKIT_FEATURE_PRESET=fp-moat pwnkit scan …
+ *   pwnkit scan --features fp-moat …
+ *
+ * The preset's membership lives in `agent/feature-presets.ts` and is pinned by
+ * test. Applying it never overwrites a flag that is already set, so
+ * `PWNKIT_FEATURE_POV_GATE=0` alongside the preset gives you a clean
+ * single-layer ablation.
+ *
+ * Enabling layers is only half of a defensible claim; the other half is being
+ * able to show which layers ran on a given finding. That is
+ * `triage/provenance.ts` (`summarizeTriageProvenance`), which reads the
+ * recorded `layerVerdicts` rather than these flags — deliberately, since a
+ * finding is usually re-read under a different environment than it was
+ * produced in. It also reports which layers emit no telemetry at all
+ * (`structured_verify`, `consensus`, `kernel_oracle` — see
+ * `UNINSTRUMENTED_LAYERS`), because a layer we cannot observe cannot be part
+ * of a moat claim.
  */
+import { FEATURE_PRESETS, resolveFeaturePreset } from "./feature-presets.js";
+
 export const features = {
   /** Early-stop at 50% budget if no findings, retry with different strategy */
   get earlyStopRetry(): boolean { return env("PWNKIT_FEATURE_EARLY_STOP", true); },
@@ -566,8 +591,29 @@ export const features = {
   },
 };
 
+/**
+ * Resolve a flag's effective default, letting `PWNKIT_FEATURE_PRESET` raise it.
+ *
+ * Consulted only when the flag's own env var is unset, so an explicit
+ * `PWNKIT_FEATURE_POV_GATE=0` still beats `PWNKIT_FEATURE_PRESET=fp-moat` —
+ * that precedence is what makes single-layer ablation possible (see
+ * `feature-presets.ts`).
+ *
+ * Doing this here rather than in the CLI is deliberate: the preset then works
+ * for EVERY entry point that reads these flags — the CLI, the cloud worker,
+ * the benchmark runner — with no per-caller wiring to forget. A CI job can set
+ * one variable and know the whole engine honours it.
+ */
+function presetRaisesDefault(key: string): boolean {
+  const raw = process.env.PWNKIT_FEATURE_PRESET;
+  if (!raw) return false;
+  const preset = resolveFeaturePreset(raw);
+  if (!preset) return false;
+  return FEATURE_PRESETS[preset].includes(key);
+}
+
 function env(key: string, defaultValue: boolean): boolean {
   const val = process.env[key];
-  if (val === undefined) return defaultValue;
+  if (val === undefined) return defaultValue || presetRaisesDefault(key);
   return val !== "0" && val !== "false";
 }

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -11,6 +11,13 @@ export type { XmlDispatchParse } from "./xml-dispatch.js";
 export { ToolExecutor, getToolsForRole, TOOL_DEFINITIONS } from "./tools.js";
 export { discoveryPrompt, attackPrompt, verifyPrompt, reportPrompt, sourceVerifyPrompt, researchPrompt, blindVerifyPrompt } from "./prompts.js";
 export { features } from "./features.js";
+export {
+  FEATURE_PRESETS,
+  applyFeaturePreset,
+  applyFeaturePresetFromEnv,
+  resolveFeaturePreset,
+} from "./feature-presets.js";
+export type { FeaturePresetName, PresetApplication } from "./feature-presets.js";
 export { PtySessionManager } from "./pty-session.js";
 export type { PtySession } from "./pty-session.js";
 export { estimateCost } from "./cost.js";

--- a/packages/core/src/agentic-scanner.ts
+++ b/packages/core/src/agentic-scanner.ts
@@ -3028,6 +3028,24 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
                 : "router excluded poc_gen",
           startedAt: Date.now(),
         });
+      } else {
+        // Flag is OFF — which is the shipped default. Record the skip so
+        // `poc_gen` is not silently absent from `layerVerdicts`.
+        //
+        // Every other layer already records its disabled state; this branch
+        // did not, so in a default scan `poc_gen` left NO trace at all. A
+        // reader of a finding could not distinguish "the PoC-gen layer was
+        // switched off" from "this engine build has no PoC-gen layer" — and
+        // an absent layer reads as an unremarkable gap rather than a
+        // deliberate configuration choice. `summarizeTriageProvenance` now
+        // reports this as `skipped` with the flag named, instead of the far
+        // weaker `unrecorded`.
+        pushLayerVerdict(finding, {
+          layer: "poc_gen",
+          verdict: "skip",
+          reason: "PWNKIT_FEATURE_POC_GEN_STATIC=0",
+          startedAt: Date.now(),
+        });
       }
 
       db.saveFinding?.(scanId, finding);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -933,6 +933,15 @@ export type { ParseSeedFindingsOptions } from "./seed-findings.js";
 
 // Agent system
 export { runAgentLoop, runNativeAgentLoop, ToolExecutor, getToolsForRole, TOOL_DEFINITIONS, features, estimateCost } from "./agent/index.js";
+// Named bundles of PWNKIT_FEATURE_* vars — the documented way to enable the
+// full FP moat for an A/B run. See `agent/feature-presets.ts`.
+export {
+  FEATURE_PRESETS,
+  applyFeaturePreset,
+  applyFeaturePresetFromEnv,
+  resolveFeaturePreset,
+} from "./agent/feature-presets.js";
+export type { FeaturePresetName, PresetApplication } from "./agent/feature-presets.js";
 export { runEGATS, runEGATSWithDefaults, scoreEvidence, summariseTree } from "./agent/egats.js";
 export {
   clearSkillRegistry,
@@ -1191,6 +1200,21 @@ export {
 
 // Handcrafted feature extractor (45-element vector for triage classifiers)
 export { extractFeatures, FEATURE_NAMES } from "./triage/feature-extractor.js";
+
+// Per-finding triage provenance — which FP-moat layers actually ran, derived
+// from the recorded `layerVerdicts` rather than the current env. See
+// `triage/provenance.ts` for why that distinction is load-bearing.
+export {
+  summarizeTriageProvenance,
+  formatTriageProvenance,
+  UNINSTRUMENTED_LAYERS,
+  OPT_IN_MOAT_LAYERS,
+} from "./triage/provenance.js";
+export type {
+  TriageProvenance,
+  LayerProvenance,
+  LayerExecutionStatus,
+} from "./triage/provenance.js";
 
 // Remediation guidance
 export { generateRemediation, generateRemediationWithLLM } from "./remediation.js";

--- a/packages/core/src/triage/index.ts
+++ b/packages/core/src/triage/index.ts
@@ -7,6 +7,17 @@
 
 export { extractFeatures, FEATURE_NAMES } from "./feature-extractor.js";
 export {
+  summarizeTriageProvenance,
+  formatTriageProvenance,
+  UNINSTRUMENTED_LAYERS,
+  OPT_IN_MOAT_LAYERS,
+} from "./provenance.js";
+export type {
+  TriageProvenance,
+  LayerProvenance,
+  LayerExecutionStatus,
+} from "./provenance.js";
+export {
   canAutoSuppress,
   canAutoSuppressDetailed,
   AUTO_SUPPRESS_PROTECTED_SEVERITIES,

--- a/packages/core/src/triage/moat-degradation.test.ts
+++ b/packages/core/src/triage/moat-degradation.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Degradation tests for the opt-in FP-moat layers.
+ *
+ * These pin the safety property that the default-ON/KEEP-OFF assessment rests
+ * on: when a moat layer's external dependency is missing — no foxguard binary,
+ * no source tree, an unreadable path — the layer must return a NEUTRAL result
+ * and never a suppression. A moat layer that rejects findings because a tool
+ * was not installed would silently destroy recall on exactly the hosts least
+ * likely to notice.
+ *
+ * They are also the precondition for enabling anything by default. A layer
+ * cannot be a safe default until its absent-dependency path is proven inert,
+ * so these tests are the evidence any future flip must cite.
+ *
+ * Note the asymmetry these encode: degrading safely is necessary but NOT
+ * sufficient for a default flip. Both layers below also carry a per-finding
+ * cost (a full repo walk / a full repo scan, neither cached across findings),
+ * which is why they remain opt-in despite passing here.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { Finding } from "@pwnkit/shared";
+import { checkMultiModalAgreement, fuseTriageSignals } from "./multi-modal.js";
+import { checkReachability } from "./reachability.js";
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: "f-1",
+    templateId: "t",
+    title: "SQL injection in src/db/query.ts",
+    description: "user input reaches a raw query in src/db/query.ts",
+    severity: "high",
+    category: "sql-injection",
+    status: "discovered",
+    evidence: { request: "", response: "", analysis: "" },
+    confidence: 0.7,
+    timestamp: Date.now(),
+    ...overrides,
+  } as Finding;
+}
+
+const MISSING_DIR = "/nonexistent-path-for-pwnkit-degradation-test";
+
+describe("multi-modal agreement degrades safely without its dependencies", () => {
+  it("returns a neutral verdict when the source tree does not exist", async () => {
+    const result = await checkMultiModalAgreement(makeFinding(), MISSING_DIR, {
+      foxguardPath: "/bin/true",
+    });
+
+    expect(result.agreement).toBe("only_pwnkit");
+    expect(result.confidence).toBe(0.5);
+    expect(result.foxguardFindings).toHaveLength(0);
+  });
+
+  it("returns a neutral verdict when the foxguard binary fails to run", async () => {
+    const result = await checkMultiModalAgreement(makeFinding(), process.cwd(), {
+      foxguardPath: "/bin/true",
+      runner: () => Promise.reject(new Error("ENOENT: foxguard not installed")),
+    });
+
+    expect(result.agreement).toBe("only_pwnkit");
+    expect(result.confidence).toBe(0.5);
+    expect(result.reasoning).toContain("foxguard");
+  });
+
+  it("produces no auto_reject from a neutral (dependency-absent) verdict", async () => {
+    const multiModal = await checkMultiModalAgreement(makeFinding(), MISSING_DIR, {
+      foxguardPath: "/bin/true",
+    });
+
+    // A high-severity finding with complete evidence must survive a scan on a
+    // host where foxguard was never installed.
+    const fused = fuseTriageSignals({
+      multiModal,
+      holdingItWrong: false,
+      evidenceCompleteness: 0.9,
+    });
+
+    expect(fused.decision).not.toBe("auto_reject");
+  });
+});
+
+describe("reachability gate degrades safely without a readable source tree", () => {
+  /**
+   * The gate only acts on `!reachable && confidence >= 0.7`. Both no-source
+   * paths must therefore land on the reachable side, or below that threshold,
+   * or both — otherwise a missing repo would look like dead code.
+   */
+  it("fails open when the source directory cannot be read", async () => {
+    const result = await checkReachability(makeFinding(), MISSING_DIR);
+
+    expect(result.reachable).toBe(true);
+    expect(result.confidence).toBeLessThan(0.7);
+  });
+
+  it("fails open when the directory exists but holds no source files", async () => {
+    const { mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const empty = mkdtempSync(join(tmpdir(), "pwnkit-reach-empty-"));
+
+    const result = await checkReachability(makeFinding(), empty);
+
+    expect(result.reachable).toBe(true);
+    expect(result.confidence).toBeLessThan(0.7);
+  });
+});

--- a/packages/core/src/triage/provenance.test.ts
+++ b/packages/core/src/triage/provenance.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for triage provenance (`provenance.ts`).
+ *
+ * The property under test throughout is the honesty of the summary: it must
+ * never report that a layer ran unless a verdict says so, and it must keep
+ * "stood down" and "left no trace" distinguishable.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import type { Finding, LayerVerdict, TriageLayerName } from "@pwnkit/shared";
+import {
+  summarizeTriageProvenance,
+  formatTriageProvenance,
+  UNINSTRUMENTED_LAYERS,
+  OPT_IN_MOAT_LAYERS,
+} from "./provenance.js";
+import { LAYER_REGISTRY } from "./router/layer-registry.js";
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: "f-1",
+    templateId: "t",
+    title: "x",
+    description: "x",
+    severity: "medium",
+    category: "xss",
+    status: "discovered",
+    evidence: { request: "", response: "", analysis: "" },
+    confidence: 0.5,
+    timestamp: Date.now(),
+    ...overrides,
+  } as Finding;
+}
+
+function verdict(
+  layer: TriageLayerName,
+  kind: LayerVerdict["verdict"],
+  overrides: Partial<LayerVerdict> = {},
+): LayerVerdict {
+  return {
+    layer,
+    verdict: kind,
+    reason: `${layer}:${kind}`,
+    durationMs: 10,
+    costUsd: 0,
+    ...overrides,
+  };
+}
+
+describe("summarizeTriageProvenance — status derivation", () => {
+  it("covers every registry layer exactly once, in canonical order", () => {
+    const provenance = summarizeTriageProvenance(makeFinding());
+    expect(provenance.layers.map((l) => l.layer)).toEqual(
+      LAYER_REGISTRY.map((e) => e.id),
+    );
+  });
+
+  /**
+   * The pre-instrumentation / empty-blob case. Reporting these as "skipped"
+   * would assert the layers deliberately stood down, which the data does not
+   * support.
+   */
+  it("reports every layer unrecorded when the finding has no verdicts", () => {
+    const provenance = summarizeTriageProvenance(makeFinding());
+
+    expect(provenance.executed).toHaveLength(0);
+    expect(provenance.skipped).toHaveLength(0);
+    expect(provenance.unrecorded).toHaveLength(LAYER_REGISTRY.length);
+    expect(provenance.moatEngaged).toBe(false);
+  });
+
+  it("classifies a non-skip verdict as executed", () => {
+    for (const kind of ["pass", "reject", "downgrade", "error"] as const) {
+      const provenance = summarizeTriageProvenance(
+        makeFinding({ layerVerdicts: [verdict("oracle", kind)] }),
+      );
+      expect(provenance.executed).toContain("oracle");
+      expect(provenance.skipped).not.toContain("oracle");
+    }
+  });
+
+  it("classifies a skip-only verdict as skipped and keeps its reason", () => {
+    const provenance = summarizeTriageProvenance(
+      makeFinding({
+        layerVerdicts: [
+          verdict("reachability", "skip", {
+            reason: "PWNKIT_FEATURE_REACHABILITY_GATE=0",
+          }),
+        ],
+      }),
+    );
+
+    const layer = provenance.layers.find((l) => l.layer === "reachability");
+    expect(layer?.status).toBe("skipped");
+    expect(layer?.reason).toBe("PWNKIT_FEATURE_REACHABILITY_GATE=0");
+  });
+
+  /** A layer that skipped once and later ran counts as executed. */
+  it("treats a layer with mixed verdicts as executed", () => {
+    const provenance = summarizeTriageProvenance(
+      makeFinding({
+        layerVerdicts: [verdict("oracle", "skip"), verdict("oracle", "pass")],
+      }),
+    );
+    expect(provenance.executed).toContain("oracle");
+    expect(provenance.layers.find((l) => l.layer === "oracle")?.verdicts).toHaveLength(2);
+  });
+
+  it("sums duration and cost across a layer's verdicts", () => {
+    const provenance = summarizeTriageProvenance(
+      makeFinding({
+        layerVerdicts: [
+          verdict("pov_gate", "pass", { durationMs: 100, costUsd: 0.25 }),
+          verdict("pov_gate", "pass", { durationMs: 50, costUsd: 0.1 }),
+        ],
+      }),
+    );
+
+    const layer = provenance.layers.find((l) => l.layer === "pov_gate");
+    expect(layer?.durationMs).toBe(150);
+    expect(layer?.costUsd).toBeCloseTo(0.35);
+    expect(provenance.totalCostUsd).toBeCloseTo(0.35);
+    expect(provenance.totalDurationMs).toBe(150);
+  });
+
+  /** Persisted JSON can outlive a layer rename; a display path must not throw. */
+  it("ignores verdicts naming a layer outside the registry", () => {
+    const provenance = summarizeTriageProvenance(
+      makeFinding({
+        layerVerdicts: [
+          { ...verdict("oracle", "pass"), layer: "ghost_layer" as TriageLayerName },
+        ],
+      }),
+    );
+    expect(provenance.executed).toHaveLength(0);
+    expect(provenance.layers).toHaveLength(LAYER_REGISTRY.length);
+  });
+});
+
+describe("summarizeTriageProvenance — moat engagement", () => {
+  /**
+   * The core claim-gate. A scan running the shipped default records only
+   * always-on layers, and that must NOT read as the FP moat having run.
+   */
+  it("reports the moat as NOT engaged when only always-on layers ran", () => {
+    const provenance = summarizeTriageProvenance(
+      makeFinding({
+        layerVerdicts: [
+          verdict("holding_it_wrong", "pass"),
+          verdict("evidence_gate", "pass"),
+          verdict("oracle", "pass"),
+          verdict("reachability", "skip"),
+          verdict("multi_modal", "skip"),
+          verdict("publishability", "skip"),
+          verdict("pov_gate", "skip"),
+          verdict("poc_gen", "skip"),
+        ],
+      }),
+    );
+
+    expect(provenance.executed).toEqual(["holding_it_wrong", "evidence_gate", "oracle"]);
+    expect(provenance.moatEngaged).toBe(false);
+    expect(provenance.moatLayersExecuted).toHaveLength(0);
+  });
+
+  it("reports the moat as engaged once an opt-in layer executes", () => {
+    const provenance = summarizeTriageProvenance(
+      makeFinding({
+        layerVerdicts: [verdict("holding_it_wrong", "pass"), verdict("pov_gate", "pass")],
+      }),
+    );
+
+    expect(provenance.moatEngaged).toBe(true);
+    expect(provenance.moatLayersExecuted).toEqual(["pov_gate"]);
+  });
+
+  /** A skipped opt-in layer is not engagement — the distinction is the point. */
+  it("does not count a skipped opt-in layer as engagement", () => {
+    const provenance = summarizeTriageProvenance(
+      makeFinding({ layerVerdicts: [verdict("pov_gate", "skip")] }),
+    );
+    expect(provenance.moatEngaged).toBe(false);
+  });
+
+  it("marks each opt-in moat layer with optInMoatLayer", () => {
+    const provenance = summarizeTriageProvenance(makeFinding());
+    const flagged = provenance.layers.filter((l) => l.optInMoatLayer).map((l) => l.layer);
+    expect(flagged.sort()).toEqual([...OPT_IN_MOAT_LAYERS].sort());
+  });
+});
+
+describe("summarizeTriageProvenance — uninstrumented layers", () => {
+  /**
+   * Pins the uninstrumented set so it cannot drift silently. If a layer starts
+   * emitting verdicts, delete it from `UNINSTRUMENTED_LAYERS` and this test
+   * will tell you to.
+   */
+  it("pins the layers that emit no telemetry anywhere in the engine", () => {
+    expect([...UNINSTRUMENTED_LAYERS].sort()).toEqual([
+      "consensus",
+      "kernel_oracle",
+      "structured_verify",
+    ]);
+  });
+
+  it("explains an uninstrumented layer differently from an unreached one", () => {
+    const provenance = summarizeTriageProvenance(makeFinding());
+
+    const consensus = provenance.layers.find((l) => l.layer === "consensus");
+    expect(consensus?.uninstrumented).toBe(true);
+    expect(consensus?.status).toBe("unrecorded");
+    expect(consensus?.reason).toContain("no instrumentation");
+
+    const oracle = provenance.layers.find((l) => l.layer === "oracle");
+    expect(oracle?.uninstrumented).toBe(false);
+    expect(oracle?.status).toBe("unrecorded");
+    expect(oracle?.reason).toContain("did not run");
+    expect(oracle?.reason).not.toContain("no instrumentation");
+  });
+});
+
+describe("summarizeTriageProvenance — reads the record, not the environment", () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  /**
+   * The rule that makes persisted findings trustworthy: turning every moat
+   * flag on in the current shell must not change the reported history of a
+   * finding produced by a scan that ran without them.
+   */
+  it("does not report a layer as executed just because its flag is on now", () => {
+    process.env.PWNKIT_FEATURE_POV_GATE = "1";
+    process.env.PWNKIT_FEATURE_REACHABILITY_GATE = "1";
+    process.env.PWNKIT_FEATURE_MULTIMODAL = "1";
+
+    const provenance = summarizeTriageProvenance(
+      makeFinding({ layerVerdicts: [verdict("holding_it_wrong", "pass")] }),
+    );
+
+    expect(provenance.executed).toEqual(["holding_it_wrong"]);
+    expect(provenance.moatEngaged).toBe(false);
+  });
+});
+
+describe("formatTriageProvenance", () => {
+  it("leads with an explicit negative when the moat did not run", () => {
+    const lines = formatTriageProvenance(
+      summarizeTriageProvenance(
+        makeFinding({ layerVerdicts: [verdict("holding_it_wrong", "pass")] }),
+      ),
+    );
+    expect(lines[0]).toContain("FP moat NOT engaged");
+  });
+
+  it("names the layers that ran when the moat did run", () => {
+    const lines = formatTriageProvenance(
+      summarizeTriageProvenance(
+        makeFinding({
+          layerVerdicts: [verdict("pov_gate", "pass"), verdict("reachability", "pass")],
+        }),
+      ),
+    );
+    expect(lines[0]).toContain("FP moat engaged");
+    expect(lines[0]).toContain("pov_gate");
+    expect(lines[0]).toContain("reachability");
+  });
+
+  it("emits one line per registry layer after the two header lines", () => {
+    const lines = formatTriageProvenance(summarizeTriageProvenance(makeFinding()));
+    expect(lines).toHaveLength(LAYER_REGISTRY.length + 2);
+  });
+});

--- a/packages/core/src/triage/provenance.ts
+++ b/packages/core/src/triage/provenance.ts
@@ -1,0 +1,277 @@
+/**
+ * Triage provenance — "which FP-moat layers actually ran for this finding?"
+ *
+ * ## Why this module exists
+ *
+ * `finding.layerVerdicts` (pwnkit#112) is an append-only log that each triage
+ * layer writes to as it executes. It is the only per-finding record of what
+ * the triage stack did. But until now it had **no reader outside the router's
+ * own feature extractor** — nothing rendered it, nothing summarized it, and
+ * nothing reconciled it against the set of layers that are supposed to exist.
+ *
+ * That is a problem for a specific and load-bearing reason: we describe triage
+ * as a multi-layer false-positive moat, but the shipped default enables only a
+ * few of those layers (see `agent/features.ts`, which says so itself). Without
+ * a reader, "the moat ran" is an assertion nobody can check — not in CI, not
+ * in a report, not when a finding is questioned months later.
+ *
+ * This module makes the claim checkable. It answers, per finding:
+ *   - which layers executed and what they decided,
+ *   - which layers explicitly recorded that they were skipped, and why,
+ *   - which layers left **no trace at all**.
+ *
+ * ## The honesty rule: read the record, not the environment
+ *
+ * A tempting shortcut is to report layer status from `features.*` — ask the
+ * flags which layers are on and call those "ran". That would be wrong, and
+ * dangerously so: findings are persisted and re-read later (`findings show`,
+ * disclosure drafting, the benchmark data collector) under a *different*
+ * environment than the scan ran in. Reading today's env would let a scan that
+ * ran with the moat off be rendered, after the fact, as though the moat had
+ * been on.
+ *
+ * So this module derives status **exclusively from the recorded verdicts**. If
+ * a layer left no verdict, we say so plainly rather than inferring anything.
+ * `features.*` is never consulted here — that is deliberate, not an oversight.
+ *
+ * ## The three statuses, and why `unrecorded` is not the same as `skipped`
+ *
+ * A layer that ran, and a layer that deliberately stood down, both leave a
+ * verdict — the second with kind `"skip"` and a reason naming the flag or the
+ * missing precondition. Those are `executed` and `skipped`.
+ *
+ * `unrecorded` is the third case and the one worth surfacing: no verdict of
+ * any kind. It means we genuinely cannot say what happened. It has two causes
+ * that a reader must be able to tell apart, so {@link LayerProvenance.reason}
+ * distinguishes them:
+ *
+ *   1. **The layer has no instrumentation at all.** `structured_verify`,
+ *      `consensus`, and `kernel_oracle` are declared in `TriageLayerName`,
+ *      have registry entries, and are routable — but no code path in the
+ *      engine emits a `LayerVerdict` for any of them. They are permanently
+ *      invisible. See {@link UNINSTRUMENTED_LAYERS}.
+ *   2. **The finding exited the pipeline early.** A finding rejected by
+ *      `holding_it_wrong` never reaches `oracle`, so `oracle` has no verdict.
+ *      That is correct behaviour and the absence is meaningful.
+ *
+ * Reporting both as a bare "skipped" would paper over (1), which is exactly
+ * the kind of unfalsifiable moat claim this module exists to prevent.
+ *
+ * See `docs/src/content/docs/triage.md` for the operator-facing view, and
+ * `agent/feature-presets.ts` for the preset that enables the full stack so an
+ * A/B run becomes possible.
+ */
+
+import type { Finding, LayerVerdict, TriageLayerName } from "@pwnkit/shared";
+import { LAYER_REGISTRY, LAYER_REGISTRY_BY_ID } from "./router/layer-registry.js";
+
+/**
+ * Whether a layer left evidence that it ran, evidence that it stood down, or
+ * no evidence at all. Derived only from recorded verdicts — never from the
+ * current environment (see the module header).
+ */
+export type LayerExecutionStatus =
+  /** At least one non-`skip` verdict: the layer ran and reached a decision. */
+  | "executed"
+  /** Only `skip` verdicts: the layer explicitly recorded that it stood down. */
+  | "skipped"
+  /** No verdict of any kind. We cannot say whether this layer ran. */
+  | "unrecorded";
+
+/**
+ * Layers that are declared, registered, and routable, but for which **no code
+ * path anywhere in the engine emits a `LayerVerdict`**. Verified by exhaustive
+ * search over every `layer:` literal in `packages/core` and `packages/cli`.
+ *
+ * They are listed here so provenance can say "this layer is uninstrumented"
+ * instead of the misleading "this layer did not run" — the distinction between
+ * a layer that stood down and a layer we simply cannot observe.
+ *
+ * Removing an entry from this list is the correct move the moment that layer
+ * starts recording verdicts; `provenance.test.ts` pins the list so it cannot
+ * drift silently.
+ */
+export const UNINSTRUMENTED_LAYERS: readonly TriageLayerName[] = [
+  "structured_verify",
+  "consensus",
+  "kernel_oracle",
+] as const;
+
+/**
+ * The opt-in false-positive moat layers — the ones gated behind a
+ * `PWNKIT_FEATURE_*` flag that is **off** in the shipped default, and which
+ * `agent/features.ts` says must be explicitly enabled before any FP-moat A/B
+ * claim can be made.
+ *
+ * `holding_it_wrong`, `evidence_gate`, and `oracle` are excluded: the first
+ * two default ON and the third is unconditional, so their execution is not
+ * what a moat claim turns on. {@link TriageProvenance.moatEngaged} counts only
+ * the layers in this set.
+ */
+export const OPT_IN_MOAT_LAYERS: readonly TriageLayerName[] = [
+  "reachability",
+  "multi_modal",
+  "publishability",
+  "structured_verify",
+  "pov_gate",
+  "poc_gen",
+  "consensus",
+] as const;
+
+/** Per-layer provenance derived from a finding's recorded verdicts. */
+export interface LayerProvenance {
+  /** Stable layer id, matching `TriageLayerName`. */
+  layer: TriageLayerName;
+  /** Human-readable layer name from the registry. */
+  name: string;
+  /** The `PWNKIT_FEATURE_*` env var that gates this layer, per the registry. */
+  envFlag: string;
+  /** Whether the layer ran, stood down, or left no trace. */
+  status: LayerExecutionStatus;
+  /**
+   * Every recorded verdict for this layer, in execution order. Usually zero or
+   * one; a layer may record more than one when it re-evaluates a finding.
+   */
+  verdicts: readonly LayerVerdict[];
+  /**
+   * The last recorded reason when the layer left a verdict, or an explanation
+   * of *why nothing was recorded* when `status` is `"unrecorded"`.
+   */
+  reason: string;
+  /** Summed wall-clock across this layer's verdicts. 0 when unrecorded. */
+  durationMs: number;
+  /** Summed USD across this layer's verdicts. 0 when unrecorded. */
+  costUsd: number;
+  /** True when this layer is in {@link UNINSTRUMENTED_LAYERS}. */
+  uninstrumented: boolean;
+  /** True when this layer is in {@link OPT_IN_MOAT_LAYERS}. */
+  optInMoatLayer: boolean;
+}
+
+/** Whole-finding triage provenance: what the moat actually did. */
+export interface TriageProvenance {
+  /** One entry per registry layer, in canonical execution order. */
+  layers: readonly LayerProvenance[];
+  /** Layers with at least one non-`skip` verdict. */
+  executed: readonly TriageLayerName[];
+  /** Layers whose only verdicts were `skip`. */
+  skipped: readonly TriageLayerName[];
+  /** Layers with no verdict at all. */
+  unrecorded: readonly TriageLayerName[];
+  /** The subset of {@link OPT_IN_MOAT_LAYERS} that actually executed. */
+  moatLayersExecuted: readonly TriageLayerName[];
+  /**
+   * True when at least one opt-in moat layer executed. This is the single
+   * value to check before describing a finding as having been through the FP
+   * moat — if it is false, the finding saw only the always-on filters.
+   */
+  moatEngaged: boolean;
+  /** Summed USD across every recorded verdict. */
+  totalCostUsd: number;
+  /** Summed wall-clock across every recorded verdict. */
+  totalDurationMs: number;
+}
+
+/**
+ * Explanation used when a layer left no verdict. Split by cause so a reader
+ * can tell "we never built the recorder" apart from "the finding stopped
+ * before this layer" — see the module header for why that matters.
+ */
+function unrecordedReason(layer: TriageLayerName): string {
+  return UNINSTRUMENTED_LAYERS.includes(layer)
+    ? "no instrumentation: this layer never emits a LayerVerdict, so its execution is unobservable"
+    : "no verdict recorded: the layer did not run, or the finding exited triage before reaching it";
+}
+
+/**
+ * Summarize what the triage stack recorded for a single finding.
+ *
+ * Pure and side-effect free. Safe on findings from any engine version: a
+ * finding with no `layerVerdicts` at all yields every layer `unrecorded`,
+ * which is the honest answer for pre-instrumentation data rather than a
+ * silent "nothing was skipped".
+ *
+ * Verdicts naming a layer outside the registry are ignored rather than
+ * throwing — `layerVerdicts` is persisted JSON that may outlive a rename.
+ */
+export function summarizeTriageProvenance(finding: Finding): TriageProvenance {
+  const recorded = new Map<TriageLayerName, LayerVerdict[]>();
+  for (const verdict of finding.layerVerdicts ?? []) {
+    if (!(verdict.layer in LAYER_REGISTRY_BY_ID)) continue;
+    const bucket = recorded.get(verdict.layer);
+    if (bucket) bucket.push(verdict);
+    else recorded.set(verdict.layer, [verdict]);
+  }
+
+  const layers: LayerProvenance[] = LAYER_REGISTRY.map((entry) => {
+    const verdicts = recorded.get(entry.id) ?? [];
+    const ran = verdicts.some((v) => v.verdict !== "skip");
+    const status: LayerExecutionStatus =
+      verdicts.length === 0 ? "unrecorded" : ran ? "executed" : "skipped";
+
+    return {
+      layer: entry.id,
+      name: entry.name,
+      envFlag: entry.env_flag,
+      status,
+      verdicts,
+      reason:
+        verdicts.length === 0
+          ? unrecordedReason(entry.id)
+          : (verdicts[verdicts.length - 1]?.reason ?? ""),
+      durationMs: verdicts.reduce((sum, v) => sum + (v.durationMs || 0), 0),
+      costUsd: verdicts.reduce((sum, v) => sum + (v.costUsd || 0), 0),
+      uninstrumented: UNINSTRUMENTED_LAYERS.includes(entry.id),
+      optInMoatLayer: OPT_IN_MOAT_LAYERS.includes(entry.id),
+    };
+  });
+
+  const byStatus = (s: LayerExecutionStatus): TriageLayerName[] =>
+    layers.filter((l) => l.status === s).map((l) => l.layer);
+
+  const moatLayersExecuted = layers
+    .filter((l) => l.optInMoatLayer && l.status === "executed")
+    .map((l) => l.layer);
+
+  return {
+    layers,
+    executed: byStatus("executed"),
+    skipped: byStatus("skipped"),
+    unrecorded: byStatus("unrecorded"),
+    moatLayersExecuted,
+    moatEngaged: moatLayersExecuted.length > 0,
+    totalCostUsd: layers.reduce((sum, l) => sum + l.costUsd, 0),
+    totalDurationMs: layers.reduce((sum, l) => sum + l.durationMs, 0),
+  };
+}
+
+/**
+ * Render provenance as plain text lines (no ANSI — the caller colorizes).
+ *
+ * The header states the moat conclusion first, because that is the question a
+ * reader actually has. When no opt-in moat layer ran, it says so explicitly
+ * rather than letting a long list of "skipped" lines imply coverage.
+ */
+export function formatTriageProvenance(provenance: TriageProvenance): string[] {
+  const lines: string[] = [];
+
+  lines.push(
+    provenance.moatEngaged
+      ? `FP moat engaged: ${provenance.moatLayersExecuted.length} opt-in layer(s) ran — ${provenance.moatLayersExecuted.join(", ")}`
+      : "FP moat NOT engaged: no opt-in moat layer ran for this finding (always-on filters only)",
+  );
+  lines.push(
+    `Layers: ${provenance.executed.length} executed, ${provenance.skipped.length} skipped, ${provenance.unrecorded.length} unrecorded` +
+      ` | ${provenance.totalDurationMs}ms | $${provenance.totalCostUsd.toFixed(4)}`,
+  );
+
+  for (const layer of provenance.layers) {
+    const marker =
+      layer.status === "executed" ? "+" : layer.status === "skipped" ? "-" : "?";
+    const verdictKinds = layer.verdicts.map((v) => v.verdict).join(",");
+    const detail = verdictKinds ? `${layer.status}(${verdictKinds})` : layer.status;
+    lines.push(`  ${marker} ${layer.layer.padEnd(18)} ${detail} — ${layer.reason}`);
+  }
+
+  return lines;
+}


### PR DESCRIPTION
## Scope
Ports legacy per-finding layer provenance, feature presets, and degradation reporting.

## Verification
- pnpm build
- pnpm lint
- pnpm test:public: passed
- focused provenance tests: 38 passed
- Foxguard diff: zero new high/critical findings
- Secret scan findings are fixture-only