### PR TITLE
feat(agent): add structured task ledger

### DIFF
--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -184,6 +184,8 @@ pwnkit ships a set of agent-improvement features behind environment-variable fla
 | `PWNKIT_FEATURE_CONTEXT_COMPACTION` | **on** | Compresses middle-of-conversation messages when the context exceeds 30k tokens. |
 | `PWNKIT_FEATURE_SCRIPT_TEMPLATES` | **on** | Adds exploit-script templates (blind SQLi, SSTI, auth chain) to the shell prompt. |
 | `PWNKIT_FEATURE_DYNAMIC_PLAYBOOKS` | off | Injects technology-specific vulnerability playbooks after the recon phase. |
+| `PWNKIT_FEATURE_AGENT_PLAN` | off | Exposes a typed `plan` tool: the agent tracks its own TODO items, re-injected each turn so they survive compaction. Off by default because it adds a tool, a system-prompt block and a per-turn block to every scan — behaviour-changing, so it must be A/B'd before shipping on. |
+| `PWNKIT_FEATURE_DRIFT_DETECTION` | off | Warns when the agent stops working the assigned objective. Distinct from the loop detector, which catches repetition; a drifting agent produces a novel action every turn and never trips it. |
 | `PWNKIT_FEATURE_JIT_SKILLS` | off | Exposes `list_skills` and `load_skill` so agents can pull narrow methodology prompts only when needed. |
 | `PWNKIT_FEATURE_EXTERNAL_MEMORY` | off | Agent writes plan/creds to disk, re-injected at reflection checkpoints. |
 | `PWNKIT_FEATURE_PROGRESS_HANDOFF` | off | Injects prior-attempt findings when retrying, so retries don't restart from zero. |

--- a/docs/src/content/docs/features.md
+++ b/docs/src/content/docs/features.md
@@ -109,6 +109,8 @@ Supported providers: **ChatGPT Codex** subscription auth, **OpenRouter**
 | Playwright browser | auto in `web` mode | Real-browser verification for XSS, cracked XBEN-011 & XBEN-018 |
 | Web search | `PWNKIT_FEATURE_WEB_SEARCH=1` | Lets the agent look up CVE details and technique references |
 | JIT skills | `PWNKIT_FEATURE_JIT_SKILLS=1` | Tool-callable methodology prompts via `list_skills` and `load_skill` |
+| Agent plan | `PWNKIT_FEATURE_AGENT_PLAN=1` | Typed TODO ledger the agent maintains itself; survives context compaction |
+| Drift detection | `PWNKIT_FEATURE_DRIFT_DETECTION=1` | Flags divergence from the assigned objective (not repetition — see the loop detector) |
 
 ## Output formats
 

--- a/docs/src/content/docs/research/agent-techniques.md
+++ b/docs/src/content/docs/research/agent-techniques.md
@@ -99,7 +99,7 @@ A catalog of every technique we have evaluated for improving pwnkit's autonomous
 
 ### 5. Dynamic Vulnerability Playbooks — SHIPPED
 
-**What:** After the initial recon phase, pattern-match tool-result text against a library of per-vulnerability playbooks and inject the best 1–3 matches into the conversation as a focused cheat-sheet. 13 playbooks are in the library: `sqli`, `ssti`, `idor`, `xss`, `ssrf`, `lfi`, `auth_bypass`, `blind_exploitation`, `cve_exploitation`, `command_injection`, `deserialization`, `request_smuggling`, `creative_idor`.
+**What:** After the initial recon phase, pattern-match tool-result text against a library of per-vulnerability playbooks and inject the best 1–3 matches into the conversation as a focused cheat-sheet. 21 playbooks are in the library: `sqli`, `structural_sqli`, `ssti`, `idor`, `access_control`, `xss`, `ssrf`, `lfi`, `auth_bypass`, `blind_exploitation`, `cve_exploitation`, `command_injection`, `deserialization`, `request_smuggling`, `creative_idor`, `prompt_injection`, `rag_poisoning`, `insecure_output_handling`, `excessive_agency`, `prompt_layer_write`, `rust_memsafety`.
 
 **Source:** CurriculumPT; Cyber-AutoAgent's self-rewriting prompts (this is the simpler cousin).
 

--- a/packages/core/src/agent/drift.test.ts
+++ b/packages/core/src/agent/drift.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Tests for task-drift detection.
+ *
+ * The two tests that matter are the pair at the top: a genuinely drifting
+ * trajectory must fire, and a focused one must NOT. Everything after them
+ * pins the specific mechanisms that buy down the false-positive rate
+ * (streak requirement, progress-tool reset, ambient subtraction, thin-anchor
+ * inertness, warning cap), because those are the parts a future change is
+ * most likely to break without noticing.
+ *
+ * Trajectories are written as literal tool-call sequences rather than
+ * generated, so it is possible to read a test and judge for yourself whether
+ * the trajectory really is drifting — which is the only honest way to assert
+ * anything about a heuristic like this.
+ */
+
+import { describe, it, expect } from "vitest";
+import { DriftMonitor, contentTerms } from "./drift.js";
+import { TaskLedger } from "./task-ledger.js";
+
+const OBJECTIVE =
+  "You are an attack agent. Assess the shop application for injection and access-control flaws in its checkout and order endpoints.";
+const TARGET = "http://shop.internal.example.com:8080";
+
+function monitor(overrides: Partial<ConstructorParameters<typeof DriftMonitor>[0]> = {}) {
+  return new DriftMonitor({ objective: OBJECTIVE, target: TARGET, ...overrides });
+}
+
+/** Shorthand for a tool call. */
+function call(name: string, args: unknown): { name: string; arguments: unknown } {
+  return { name, arguments: args };
+}
+
+describe("drift fires on a genuinely drifting trajectory", () => {
+  it("fires after a sustained run of turns unrelated to the plan or objective", () => {
+    const plan = new TaskLedger();
+    plan.add("Test checkout endpoint for SQL injection", undefined, 1);
+    plan.add("Probe order lookup for broken access control", undefined, 1);
+    plan.start("task-1", 1);
+    const planText = plan.openText();
+
+    const m = monitor();
+
+    // Turn 1: on-task — the agent is probing checkout, which is in the plan.
+    m.record([call("http_request", { url: `${TARGET}/checkout?id=1'` })], planText);
+    expect(m.detect()).toBeNull();
+
+    // Turns 2-5: the agent wanders off into unrelated infrastructure poking.
+    // None of this touches checkout, orders, injection, or access control.
+    m.record([call("bash", { command: "nslookup mail.example.org" })], planText);
+    expect(m.detect()).toBeNull();
+    m.record([call("bash", { command: "whois example.org" })], planText);
+    expect(m.detect()).toBeNull();
+    m.record([call("http_request", { url: "https://cdn.jsdelivr.example/lib.js" })], planText);
+    expect(m.detect()).toBeNull(); // streak 3 — still under threshold
+
+    m.record([call("bash", { command: "cat /proc/cpuinfo" })], planText);
+    const warning = m.detect();
+
+    expect(warning).not.toBeNull();
+    expect(warning).toContain("drift check");
+    expect(warning).toContain("checkout"); // the message restates the open plan
+    expect(m.state.streak).toBe(4);
+    expect(m.state.warningsIssued).toBe(1);
+  });
+
+  it("fires against the objective alone when no plan has been recorded", () => {
+    const m = monitor();
+    for (let i = 0; i < 4; i++) {
+      m.record([call("bash", { command: `nslookup host${i}.unrelated.org` })], "");
+    }
+    // The objective supplies enough anchor terms (shop, application, injection,
+    // access, control, checkout, order, endpoints) to judge against.
+    expect(m.detect()).not.toBeNull();
+  });
+});
+
+describe("drift does NOT fire on a focused trajectory", () => {
+  it("stays silent across a long run that keeps contacting the plan", () => {
+    const plan = new TaskLedger();
+    plan.add("Test checkout endpoint for SQL injection", undefined, 1);
+    plan.start("task-1", 1);
+    const planText = plan.openText();
+
+    const m = monitor();
+    const focused = [
+      call("http_request", { url: `${TARGET}/checkout?id=1'` }),
+      call("http_request", { url: `${TARGET}/checkout?id=1 OR 1=1` }),
+      call("bash", { command: `curl -s '${TARGET}/checkout?id=1 UNION SELECT null'` }),
+      call("http_request", { url: `${TARGET}/checkout?id=1 AND SLEEP(5)` }),
+      call("bash", { command: "python3 blind_injection_timing.py --param id" }),
+      call("http_request", { url: `${TARGET}/checkout?id=2` }),
+      call("bash", { command: `sqlmap-style manual probe against checkout` }),
+      call("http_request", { url: `${TARGET}/checkout?id=3'--` }),
+    ];
+    for (const c of focused) {
+      m.record([c], planText);
+      expect(m.detect()).toBeNull();
+    }
+    expect(m.state.streak).toBe(0);
+    expect(m.state.warningsIssued).toBe(0);
+  });
+
+  it("does not fire on a short exploratory detour", () => {
+    const plan = new TaskLedger();
+    plan.add("Test checkout endpoint for SQL injection", undefined, 1);
+    const planText = plan.openText();
+
+    const m = monitor();
+    m.record([call("http_request", { url: `${TARGET}/checkout?id=1` })], planText);
+    // Three off-plan turns — genuine exploration, below the streak threshold.
+    m.record([call("bash", { command: "nslookup mail.example.org" })], planText);
+    m.record([call("bash", { command: "whois example.org" })], planText);
+    m.record([call("http_request", { url: "https://cdn.example/lib.js" })], planText);
+    expect(m.detect()).toBeNull();
+    expect(m.state.streak).toBe(3);
+
+    // Back on task — the streak resets and the detour cost nothing.
+    m.record([call("http_request", { url: `${TARGET}/checkout?id=2'` })], planText);
+    expect(m.detect()).toBeNull();
+    expect(m.state.streak).toBe(0);
+  });
+
+  it("does not fire when the agent is recording progress, whatever the vocabulary", () => {
+    const plan = new TaskLedger();
+    plan.add("Test checkout endpoint for SQL injection", undefined, 1);
+    const planText = plan.openText();
+
+    const m = monitor();
+    // Off-plan vocabulary throughout, but the agent keeps saving findings —
+    // direct evidence it is engaged, so the lexical signal is overridden.
+    for (let i = 0; i < 6; i++) {
+      m.record(
+        [
+          call("bash", { command: `probe unrelated-service-${i}` }),
+          call("save_finding", { title: `something at unrelated-service-${i}` }),
+        ],
+        planText,
+      );
+      expect(m.detect()).toBeNull();
+    }
+    expect(m.state.streak).toBe(0);
+  });
+
+  it("stays inert when the anchor set is too thin to judge against", () => {
+    // A generic objective and no plan: nothing to drift FROM.
+    const m = new DriftMonitor({ objective: "Find bugs.", target: TARGET });
+    for (let i = 0; i < 10; i++) {
+      m.record([call("bash", { command: `some command ${i}` })], "");
+    }
+    expect(m.detect()).toBeNull();
+    expect(m.state.anchorSize).toBeLessThan(3);
+  });
+});
+
+describe("ambient subtraction — the target must not anchor", () => {
+  /**
+   * The failure this guards against is a false NEGATIVE, and it is the single
+   * easiest way to make the whole detector useless: `config.target` appears in
+   * essentially every tool call, so leaving its tokens in the anchor set would
+   * mean contact is always true and drift never fires. Here the agent is doing
+   * something completely off-plan but still against the target host.
+   */
+  it("still detects drift when off-plan activity hits the target host", () => {
+    const plan = new TaskLedger();
+    plan.add("Test checkout endpoint for SQL injection", undefined, 1);
+    const planText = plan.openText();
+
+    const m = monitor();
+    for (let i = 0; i < 4; i++) {
+      m.record([call("http_request", { url: `${TARGET}/static/img/logo${i}.png` })], planText);
+    }
+    expect(m.detect()).not.toBeNull();
+  });
+
+  it("excludes target tokens from the anchor even when the objective repeats them", () => {
+    const terms = contentTerms(TARGET);
+    expect(terms.has("shop")).toBe(true);
+    expect(terms.has("internal")).toBe(true);
+    // `http`, `com` and the port number are noise/numeric and never terms.
+    expect(terms.has("http")).toBe(false);
+    expect(terms.has("com")).toBe(false);
+    expect(terms.has("8080")).toBe(false);
+  });
+});
+
+describe("neutral and empty turns", () => {
+  it("treats a bookkeeping-only turn as neither drift nor focus", () => {
+    const plan = new TaskLedger();
+    plan.add("Test checkout endpoint for SQL injection", undefined, 1);
+    const planText = plan.openText();
+
+    const m = monitor();
+    m.record([call("bash", { command: "nslookup unrelated.org" })], planText);
+    expect(m.state.streak).toBe(1);
+    // query_findings / use_loot say nothing about focus either way.
+    m.record([call("query_findings", { limit: 20 })], planText);
+    m.record([call("use_loot", { kind: "credential" })], planText);
+    expect(m.state.streak).toBe(1);
+  });
+
+  it("ignores a turn with no tool calls", () => {
+    const m = monitor();
+    m.record([], "");
+    m.record([], "");
+    expect(m.state.streak).toBe(0);
+  });
+});
+
+describe("re-arming and the warning cap", () => {
+  it("warns once per episode, not once per turn", () => {
+    const plan = new TaskLedger();
+    plan.add("Test checkout endpoint for SQL injection", undefined, 1);
+    const planText = plan.openText();
+
+    const m = monitor();
+    for (let i = 0; i < 4; i++) {
+      m.record([call("bash", { command: `nslookup host${i}.unrelated.org` })], planText);
+    }
+    expect(m.detect()).not.toBeNull();
+    // Still drifting, but the episode has already been reported.
+    for (let i = 0; i < 5; i++) {
+      m.record([call("bash", { command: `whois host${i}.unrelated.org` })], planText);
+      expect(m.detect()).toBeNull();
+    }
+    expect(m.state.warningsIssued).toBe(1);
+  });
+
+  it("re-arms after the agent returns to the plan", () => {
+    const plan = new TaskLedger();
+    plan.add("Test checkout endpoint for SQL injection", undefined, 1);
+    const planText = plan.openText();
+
+    const m = monitor();
+    for (let i = 0; i < 4; i++) {
+      m.record([call("bash", { command: `nslookup host${i}.unrelated.org` })], planText);
+    }
+    expect(m.detect()).not.toBeNull();
+
+    // Back on task — the latch clears.
+    m.record([call("http_request", { url: `${TARGET}/checkout?id=1'` })], planText);
+    expect(m.state.streak).toBe(0);
+
+    // A second, distinct drift episode gets its own warning.
+    for (let i = 0; i < 4; i++) {
+      m.record([call("bash", { command: `traceroute node${i}.elsewhere.org` })], planText);
+    }
+    expect(m.detect()).not.toBeNull();
+    expect(m.state.warningsIssued).toBe(2);
+  });
+
+  it("never exceeds maxWarnings, so it cannot become a nag", () => {
+    const plan = new TaskLedger();
+    plan.add("Test checkout endpoint for SQL injection", undefined, 1);
+    const planText = plan.openText();
+
+    const m = monitor({ maxWarnings: 2 });
+    for (let episode = 0; episode < 5; episode++) {
+      for (let i = 0; i < 4; i++) {
+        m.record([call("bash", { command: `probe-${episode}-${i} elsewhere.org` })], planText);
+      }
+      m.detect();
+      m.record([call("http_request", { url: `${TARGET}/checkout?id=1'` })], planText);
+    }
+    expect(m.state.warningsIssued).toBe(2);
+  });
+});
+
+describe("completing tasks changes what counts as drift", () => {
+  /**
+   * Directly tests the coupling between the two modules: a completed task must
+   * stop anchoring, otherwise finished work suppresses drift for the rest of
+   * the run. Same trajectory, different plan state, opposite verdicts.
+   *
+   * The objective used here deliberately does NOT name the checkout endpoint,
+   * so the plan is the only anchor and completing a task can actually change
+   * the verdict. With the module-level OBJECTIVE (which does say "checkout")
+   * this trajectory correctly never drifts, because the objective anchor is
+   * permanent and outranks the plan — an accurate and useful property, just not
+   * the one under test here.
+   */
+  it("work on a COMPLETED task no longer counts as contact", () => {
+    const planOnlyObjective =
+      "You are an attack agent. Work through the tasks you have recorded on your plan.";
+    const plan = new TaskLedger();
+    plan.add("Test checkout parameters for SQL injection", undefined, 1);
+    plan.add("Review the newsletter signup form", undefined, 1);
+
+    const stillOpen = new DriftMonitor({ objective: planOnlyObjective, target: TARGET });
+    for (let i = 0; i < 4; i++) {
+      stillOpen.record(
+        [call("http_request", { url: `${TARGET}/checkout?id=${i}'` })],
+        plan.openText(),
+      );
+    }
+    expect(stillOpen.detect()).toBeNull(); // checkout is open — on task
+
+    plan.complete("task-1", undefined, 5);
+    const afterComplete = new DriftMonitor({ objective: planOnlyObjective, target: TARGET });
+    for (let i = 0; i < 4; i++) {
+      afterComplete.record(
+        [call("http_request", { url: `${TARGET}/checkout?id=${i}'` })],
+        plan.openText(),
+      );
+    }
+    // The only open task is now the newsletter form; continuing to grind on
+    // checkout is drift, and the detector says so.
+    expect(afterComplete.detect()).not.toBeNull();
+  });
+
+  /**
+   * The complement, stated as its own test because it is a real and
+   * intentional limitation rather than an oversight: a term that appears in the
+   * OBJECTIVE anchors for the whole run and no amount of plan bookkeeping can
+   * retire it. That is why the objective anchor is deliberately built from a
+   * bounded prefix of the system prompt in native-loop.ts — the wider the
+   * objective, the less this detector can ever see.
+   */
+  it("objective terms keep anchoring even after every plan task is closed", () => {
+    const plan = new TaskLedger();
+    plan.add("Test checkout parameters for SQL injection", undefined, 1);
+    plan.complete("task-1", undefined, 2);
+
+    const m = monitor(); // module OBJECTIVE names checkout
+    for (let i = 0; i < 6; i++) {
+      m.record([call("http_request", { url: `${TARGET}/checkout?id=${i}'` })], plan.openText());
+    }
+    expect(m.detect()).toBeNull();
+  });
+});
+
+describe("the source-navigation false-positive case", () => {
+  /**
+   * The specific FP mode worth pinning: an agent reading unfamiliar code in
+   * order to REACH the objective. Both halves are asserted because the honest
+   * position is that one of them is a real, accepted false positive rather
+   * than a solved problem.
+   */
+  it("tolerates an orientation pass that reaches an anchored file in time", () => {
+    const plan = new TaskLedger();
+    plan.add("Audit the payment processor for injection flaws", undefined, 1);
+    const planText = plan.openText();
+
+    const m = monitor({ streakThreshold: 4 });
+    // Three turns of unfamiliar-tree navigation — no anchor contact at all.
+    m.record([call("list_dir", { path: "src/internal/bootstrap" })], planText);
+    m.record([call("read_file", { path: "src/internal/bootstrap/registry.ts" })], planText);
+    m.record([call("grep", { pattern: "registerHandler", path: "src" })], planText);
+    expect(m.detect()).toBeNull();
+    expect(m.state.streak).toBe(3);
+
+    // The fourth turn opens a file belonging to the subsystem the plan names,
+    // which is the normal shape of orientation reading: it converges.
+    m.record([call("read_file", { path: "src/payment/processor.ts" })], planText);
+    expect(m.detect()).toBeNull();
+    expect(m.state.streak).toBe(0);
+  });
+
+  it("DOES fire on a long orientation pass that never reaches the objective (accepted FP)", () => {
+    const plan = new TaskLedger();
+    plan.add("Audit the payment processor for injection flaws", undefined, 1);
+    const planText = plan.openText();
+
+    const m = monitor({ streakThreshold: 4 });
+    for (const path of [
+      "src/internal/bootstrap/registry.ts",
+      "src/internal/telemetry/exporter.ts",
+      "src/internal/config/loader.ts",
+      "src/internal/logging/format.ts",
+    ]) {
+      m.record([call("read_file", { path })], planText);
+    }
+    // Documented behavior, not an accident: four consecutive turns of source
+    // navigation with zero anchor contact trips the detector even though the
+    // agent may still be orienting. The intervention is advisory, so the cost
+    // is one message telling it to record what it is doing on the plan.
+    expect(m.detect()).not.toBeNull();
+  });
+});
+
+describe("robustness", () => {
+  it("does not throw on unstringifiable tool arguments", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const m = monitor();
+    expect(() => m.record([call("bash", circular)], "")).not.toThrow();
+  });
+
+  it("honors a custom streak threshold", () => {
+    const plan = new TaskLedger();
+    plan.add("Test checkout endpoint for SQL injection", undefined, 1);
+    const planText = plan.openText();
+
+    const m = monitor({ streakThreshold: 2 });
+    m.record([call("bash", { command: "nslookup a.unrelated.org" })], planText);
+    expect(m.detect()).toBeNull();
+    m.record([call("bash", { command: "nslookup b.unrelated.org" })], planText);
+    expect(m.detect()).not.toBeNull();
+  });
+});

--- a/packages/core/src/agent/drift.ts
+++ b/packages/core/src/agent/drift.ts
@@ -1,0 +1,410 @@
+/**
+ * Task-drift detection — is the agent still working the thing it said it was
+ * working on?
+ *
+ * The engine already had two things that look adjacent and are not:
+ *
+ * - `LoopDetector` (`agent/native-loop.ts`) catches an agent REPEATING itself
+ *   (same fingerprint 3× in a row, or A-B-A-B). That is stuckness, not drift.
+ *   A drifting agent is the opposite shape: it is doing something new every
+ *   turn, none of it related to the objective, so every loop-detector signature
+ *   is unique and it never fires.
+ * - The percentage-keyed prompts (`buildContinuePrompt`, 30/50/70/85%) and the
+ *   Strix budget warnings are keyed on BUDGET CONSUMED, not on content. They
+ *   fire on a perfectly focused run and a completely derailed one identically,
+ *   because neither one looks at what the agent is actually doing.
+ *
+ * Nothing measured divergence from the assigned objective. This does.
+ *
+ * ## The signal, and why it is deterministic rather than an LLM call
+ *
+ * Per turn, we compute lexical **anchor contact**: does this turn's activity
+ * share any content term with the objective plus the currently OPEN plan tasks?
+ * Drift is declared when contact has been absent for `streakThreshold`
+ * consecutive scored turns.
+ *
+ *   ambient  = tokens(target) ∪ NOISE_TERMS
+ *   anchor   = (tokens(objective) ∪ tokens(open plan tasks)) − ambient
+ *   activity = tokens(tool names + tool arguments this turn) − ambient
+ *   contact  = |anchor ∩ activity| >= 1
+ *
+ * Subtracting `ambient` is the part that makes this work at all. `config.target`
+ * appears verbatim in essentially every `http_request` / `crawl` / `bash` call
+ * an agent makes, so leaving the target host in the anchor set would make
+ * contact permanently true and the detector permanently silent — a
+ * false-NEGATIVE machine. Hitting the target is what the agent does by
+ * definition; it carries no information about whether it is on-task. The same
+ * reasoning removes HTTP/JSON boilerplate (`method`, `headers`, `true`, `json`,
+ * …), which is present in every tool call regardless of intent.
+ *
+ * An LLM-judged alternative ("ask a cheap model each turn whether this is still
+ * on-task") was rejected. The comparison that matters is not accuracy in the
+ * abstract, it is accuracy per dollar per turn in a loop that already re-sends
+ * the whole transcript every turn:
+ *
+ * - **Cost.** A per-turn judge call on a 40-turn run is 40 extra model calls
+ *   per agent, and the engine fans agents out (specialists, EGATS branches,
+ *   the verify wave). Measured verify-call cost in this codebase runs ~$0.55
+ *   per LLM verification pass; even at a tenth of that, a per-turn judge is a
+ *   double-digit-percent tax on scan cost to police a failure mode that does
+ *   not occur on most runs. The token cost of THIS detector is zero — it never
+ *   touches the network.
+ * - **Latency.** It sits on the critical path of every turn.
+ *   `Set.prototype.has` does not.
+ * - **Determinism.** A judge that itself hallucinates drift injects a
+ *   re-anchoring message into a healthy run, and it does so nonreproducibly,
+ *   which makes the feature impossible to A/B honestly. This detector is a pure
+ *   function of the trajectory: same run in, same warnings out, every time.
+ * - **Circularity.** The judge would be the same model family that is drifting,
+ *   asked to notice that it is drifting, from the same context that caused it.
+ *
+ * The honest summary is that the deterministic signal is a coarser instrument
+ * bought at ~1/1000th the cost, and coarseness is affordable here because the
+ * intervention is a short advisory message rather than a hard stop.
+ *
+ * ## What this signal genuinely cannot see (read this before trusting it)
+ *
+ * 1. **Lexically-disguised drift.** An agent that abandons the objective but
+ *    keeps using the objective's vocabulary — endlessly re-probing an already-
+ *    proven SQLi while the plan says "move to the auth bypass" — stays in
+ *    contact on every turn and never trips. This is probably the most common
+ *    real drift mode, and this detector misses it. Catching it needs semantics.
+ * 2. **Legitimate pivots read as drift.** Discovering a new host, a new
+ *    subdomain, or an unplanned CVE lead produces genuinely novel vocabulary
+ *    with zero anchor overlap. This is the primary false-positive source and it
+ *    is not a bug in the tokenizer — a real pivot and a real derail are
+ *    lexically indistinguishable. The mitigations are structural, not clever:
+ *    the streak requirement (a single exploratory turn never fires), the
+ *    `plan`/`save_finding` reset (an agent recording progress is by definition
+ *    on-task, whatever the words say), and an intervention that is advisory —
+ *    the message explicitly tells the agent that if the new direction is right,
+ *    the correct response is to ADD it to the plan, not to abandon it. A false
+ *    positive therefore costs one short message and produces a useful side
+ *    effect (the plan gets updated) rather than derailing the run.
+ *
+ *    The sharpest instance of this, and the one to keep in mind before turning
+ *    the flag on for white-box work: **an agent reading unfamiliar code in
+ *    order to REACH the objective.** A `read_file` / `grep` walk through a
+ *    codebase it has never seen produces filenames, symbols and framework
+ *    vocabulary that match nothing in the plan, even though the reading is
+ *    exactly the right thing to be doing. The streak requirement is what makes
+ *    this survivable — four consecutive turns of source navigation with no
+ *    contact at all is genuinely a lot, and orientation reading normally
+ *    touches an anchored term as soon as it opens a file belonging to the
+ *    subsystem the plan names. It is nevertheless the case that a long
+ *    orientation pass on a large unfamiliar tree WILL trip this detector, and
+ *    that is an accepted false positive rather than a solved problem. Two
+ *    tests below pin both halves of the behavior. If this proves noisy on
+ *    audit/review roles, raise `streakThreshold` for those roles rather than
+ *    widening the noise list, which would cost real signal.
+ * 3. **An empty or generic plan.** With fewer than `minAnchorTerms` distinct
+ *    anchor terms the detector disables itself entirely rather than guessing.
+ *    A run whose objective is "find vulnerabilities" and whose plan is empty
+ *    has nothing to drift FROM, and firing there would be noise by
+ *    construction.
+ *
+ * **No false-positive rate is claimed.** Quantifying it requires labelled
+ * trajectories — replaying stored XBOW/CyberGym runs through the monitor and
+ * having a human mark which fires were genuine derails — and that corpus does
+ * not exist yet. Until it does, this ships behind a default-OFF flag. The
+ * structural claim being made is narrower and testable from the code: the
+ * detector cannot fire on a run that maintains anchor contact, cannot fire more
+ * than `maxWarnings` times, and cannot fire on a run with a thin anchor set.
+ */
+
+/**
+ * Tokens too common to carry intent. Anything here appears across on-task and
+ * off-task turns alike, so counting it as contact would only manufacture
+ * false negatives. Kept deliberately short — the `ambient` subtraction of the
+ * target string does most of the real work, and an over-long stoplist starts
+ * removing genuine signal (`admin`, `token`, `upload` are all noise-adjacent
+ * and all meaningful).
+ */
+const NOISE_TERMS = new Set([
+  // HTTP / tooling boilerplate present in nearly every tool call
+  "http", "https", "www", "com", "net", "org", "url", "uri", "host", "port",
+  "get", "post", "put", "patch", "head", "method", "header", "headers",
+  "body", "data", "json", "xml", "html", "text", "content", "type", "length",
+  "accept", "agent", "user", "curl", "wget", "bash", "sh", "cmd", "command",
+  "true", "false", "null", "undefined", "none", "nan",
+  // generic English connectives that survive a 3-char filter
+  "the", "and", "for", "with", "from", "this", "that", "into", "onto", "via",
+  "any", "all", "not", "but", "its", "was", "are", "has", "have", "can",
+  "try", "use", "using", "then", "when", "what", "which", "should", "would",
+  // engine vocabulary the agent is told to use, so it says nothing about focus
+  "target", "scan", "test", "check", "find", "look", "run", "step", "task",
+  "tool", "call", "result", "output", "input", "value", "name", "file", "path",
+]);
+
+/**
+ * Tool calls that are DIRECT evidence of on-task behavior. A turn containing
+ * any of these resets the streak unconditionally, without looking at
+ * vocabulary. Rationale: an agent that just recorded a finding or updated its
+ * plan is by definition still engaged with the objective, and no lexical
+ * heuristic should be allowed to overrule that. This removes a large class of
+ * false positives at essentially no cost in false negatives — a truly derailed
+ * agent is not saving findings.
+ */
+const PROGRESS_TOOLS = new Set([
+  "plan",
+  "save_finding",
+  "update_finding",
+  "done",
+]);
+
+/**
+ * Read-only bookkeeping tools. They are neither evidence of focus nor of
+ * drift, so a turn made up solely of these is skipped: it neither advances nor
+ * resets the streak. Scoring them would let an agent mask drift by polling
+ * `query_findings`, and counting them as drift would punish legitimate lookup.
+ */
+const NEUTRAL_TOOLS = new Set([
+  "query_findings",
+  "use_loot",
+  "list_skills",
+  "load_skill",
+  "oast_poll",
+]);
+
+/** Tokens shorter than this are dropped. 3 keeps `xss`, `lfi`, `jwt`, `ssh`. */
+const MIN_TERM_LEN = 3;
+
+/**
+ * Split text into content terms. Lowercased, split on any non-alphanumeric run
+ * (so URLs, snake_case, camel boundaries via punctuation, and JSON all shred
+ * into words), pure-numeric tokens dropped — a status code or an incrementing
+ * IDOR id says nothing about topic.
+ */
+export function contentTerms(text: string): Set<string> {
+  const out = new Set<string>();
+  if (!text) return out;
+  for (const raw of text.toLowerCase().split(/[^a-z0-9]+/)) {
+    if (raw.length < MIN_TERM_LEN) continue;
+    if (/^\d+$/.test(raw)) continue;
+    if (NOISE_TERMS.has(raw)) continue;
+    out.add(raw);
+  }
+  return out;
+}
+
+export interface DriftMonitorOptions {
+  /**
+   * The assigned objective in prose — typically the role + task line of the
+   * system prompt. Contributes anchor terms so the detector still works before
+   * the agent has written any plan.
+   */
+  objective: string;
+  /**
+   * The scan target. Its tokens are subtracted from BOTH the anchor and the
+   * activity sets (see the module doc) — every tool call contains the target,
+   * so it is pure ambient signal.
+   */
+  target: string;
+  /**
+   * Consecutive no-contact scored turns before drift fires. Default 4.
+   *
+   * This default is derived STRUCTURALLY, not empirically, and the distinction
+   * matters enough to record: the repo contains no stored agent trajectories to
+   * calibrate against (`packages/benchmark/results/*.jsonl` are per-task
+   * outcome and triage-label datasets, not turn-by-turn tool-call traces), so
+   * there was nothing to fit a threshold to. It is bracketed by two existing
+   * constants instead:
+   *
+   * - The `LoopDetector` in `native-loop.ts` intervenes at 3 identical calls or
+   *   2 full A-B cycles (4 entries). That is this codebase's established view
+   *   of how much repetition justifies interrupting the model, and drift should
+   *   not be twitchier than the detector that already ships.
+   * - The budget checkpoints fire at 30/50/70/85%, i.e. every 6-12 turns on a
+   *   typical 20-40 turn run. A drift warning firing more often than those
+   *   would be perceived as noise regardless of accuracy.
+   *
+   * 4 sits between them. Treat it as a starting point to be replaced the first
+   * time real labelled trajectories exist — that measurement, not this
+   * reasoning, is what should set it.
+   */
+  streakThreshold?: number;
+  /** Below this many anchor terms the monitor stays inert. Default 3. */
+  minAnchorTerms?: number;
+  /** Hard cap on warnings per run, so this can never become a nag. Default 3. */
+  maxWarnings?: number;
+}
+
+/** Snapshot of the monitor's internal state, for events and tests. */
+export interface DriftState {
+  /** Consecutive scored turns with no anchor contact. */
+  streak: number;
+  /** Number of anchor terms currently in play. */
+  anchorSize: number;
+  /** Warnings issued so far this run. */
+  warningsIssued: number;
+}
+
+/**
+ * Tracks anchor contact across turns and emits a re-anchoring message when
+ * contact has been absent long enough to look like drift rather than
+ * exploration.
+ *
+ * Shaped after `LoopDetector` on purpose — `record()` then `detect()`, called
+ * back to back from the same place in the loop, with a fired-latch so one
+ * episode produces one warning instead of one per turn.
+ */
+export class DriftMonitor {
+  private readonly objectiveTerms: Set<string>;
+  private readonly ambient: Set<string>;
+  private readonly streakThreshold: number;
+  private readonly minAnchorTerms: number;
+  private readonly maxWarnings: number;
+
+  private streak = 0;
+  private warningsIssued = 0;
+  /** Latched when a warning fires; cleared on the next contact turn. */
+  private fired = false;
+  /** Anchor terms as of the last `record()`, cached for `detect()`/events. */
+  private lastAnchorSize = 0;
+  /** Open-plan prose as of the last `record()`, used to build the message. */
+  private lastPlanSummary = "";
+
+  constructor(opts: DriftMonitorOptions) {
+    this.ambient = contentTerms(opts.target);
+    // Objective terms are computed once: the objective does not change
+    // mid-run, and recomputing per turn would be pure waste.
+    this.objectiveTerms = subtract(contentTerms(opts.objective), this.ambient);
+    this.streakThreshold = opts.streakThreshold ?? 4;
+    this.minAnchorTerms = opts.minAnchorTerms ?? 3;
+    this.maxWarnings = opts.maxWarnings ?? 3;
+  }
+
+  get state(): DriftState {
+    return {
+      streak: this.streak,
+      anchorSize: this.lastAnchorSize,
+      warningsIssued: this.warningsIssued,
+    };
+  }
+
+  /**
+   * Record one turn's tool calls.
+   *
+   * @param calls    The tool calls the model emitted this turn.
+   * @param planText Free text of the currently OPEN plan tasks
+   *                 (`TaskLedger.openText()`), or `""` when there is no plan.
+   *                 Passed per-turn rather than held, because the open set
+   *                 changes as tasks are completed and dropped — and a
+   *                 completed task must stop anchoring immediately.
+   */
+  record(calls: Array<{ name: string; arguments: unknown }>, planText: string): void {
+    this.lastPlanSummary = planText;
+    const anchor = this.buildAnchor(planText);
+    this.lastAnchorSize = anchor.size;
+
+    if (calls.length === 0) return; // a no-tool turn is not activity
+
+    // Direct evidence of progress overrides the lexical signal entirely.
+    if (calls.some((c) => PROGRESS_TOOLS.has(c.name))) {
+      this.reset();
+      return;
+    }
+
+    const scored = calls.filter((c) => !NEUTRAL_TOOLS.has(c.name));
+    if (scored.length === 0) return; // bookkeeping-only turn: neither way
+
+    const activity = subtract(activityTerms(scored), this.ambient);
+    if (intersects(anchor, activity)) {
+      this.reset();
+      return;
+    }
+    this.streak += 1;
+  }
+
+  /**
+   * Returns a re-anchoring message when drift is detected, else `null`. Safe to
+   * call every turn; the fired-latch and `maxWarnings` cap guarantee at most
+   * one message per drift episode and at most `maxWarnings` per run.
+   */
+  detect(): string | null {
+    if (this.fired) return null;
+    if (this.warningsIssued >= this.maxWarnings) return null;
+    // Too thin an anchor to judge against — stay silent rather than guess.
+    if (this.lastAnchorSize < this.minAnchorTerms) return null;
+    if (this.streak < this.streakThreshold) return null;
+
+    this.fired = true;
+    this.warningsIssued += 1;
+    return buildReanchorMessage(this.streak, this.lastPlanSummary);
+  }
+
+  private reset(): void {
+    this.streak = 0;
+    this.fired = false;
+  }
+
+  private buildAnchor(planText: string): Set<string> {
+    if (!planText) return this.objectiveTerms;
+    const merged = new Set(this.objectiveTerms);
+    for (const t of subtract(contentTerms(planText), this.ambient)) merged.add(t);
+    return merged;
+  }
+}
+
+/** Terms from a turn's tool names and stringified arguments. */
+function activityTerms(calls: Array<{ name: string; arguments: unknown }>): Set<string> {
+  const parts: string[] = [];
+  for (const c of calls) {
+    parts.push(c.name);
+    parts.push(
+      typeof c.arguments === "string" ? c.arguments : safeStringify(c.arguments),
+    );
+  }
+  return contentTerms(parts.join(" "));
+}
+
+/**
+ * `JSON.stringify` on model-supplied arguments can throw (circular refs from a
+ * malformed provider payload). Tokenization must never be the thing that ends
+ * a scan, so a failure degrades to no terms — which at worst counts the turn
+ * as a no-contact turn.
+ */
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value ?? "");
+  } catch {
+    return "";
+  }
+}
+
+function subtract(set: Set<string>, remove: Set<string>): Set<string> {
+  const out = new Set<string>();
+  for (const t of set) if (!remove.has(t)) out.add(t);
+  return out;
+}
+
+function intersects(a: Set<string>, b: Set<string>): boolean {
+  // Iterate the smaller set — anchors are usually small, activity on a
+  // `bash` turn with a long script can be large.
+  const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+  for (const t of small) if (large.has(t)) return true;
+  return false;
+}
+
+/**
+ * The intervention. Deliberately framed as a question rather than a
+ * correction, because the detector cannot tell a derail from a legitimate
+ * pivot (see the module doc) and the message has to be useful in BOTH cases.
+ * On a real derail it re-states the objective; on a real pivot it prompts the
+ * agent to record the new direction in the plan, which is what should have
+ * happened anyway and which restores anchor contact so the detector stops
+ * firing.
+ */
+export function buildReanchorMessage(streak: number, planText: string): string {
+  const planLine = planText
+    ? `Your open plan is: ${planText.slice(0, 400)}`
+    : "You have no open plan tasks recorded.";
+  return [
+    `[pwnkit drift check] Your last ${streak} turns have no apparent connection to your objective or your open plan.`,
+    planLine,
+    "Stop and answer, in one line, before your next tool call: which open task does this work serve?",
+    "- If it serves an open task, say which one and continue.",
+    "- If you have deliberately pivoted to a better lead, that is fine — but record it: call `plan` with action='add' to add the new task, then action='start' to make it current, and `drop` the tasks you have abandoned.",
+    "- If you cannot connect the last few turns to anything on the plan, you have drifted. Return to the active task.",
+  ].join("\n");
+}

--- a/packages/core/src/agent/features.ts
+++ b/packages/core/src/agent/features.ts
@@ -543,6 +543,59 @@ export const features = {
   },
 
   /**
+   * Typed TODO / plan ledger (`packages/core/src/agent/task-ledger.ts`).
+   *
+   * When ON, the agent gets a `plan` tool that maintains a typed, validated
+   * task list (add / start / complete / drop / note / list), and the loop
+   * re-injects a compact plan block re-rendered from that structured state —
+   * so the plan survives `compactMessagesWithLLM` eating the message that
+   * carried it. Prior art: Tencent Xuanwu's Atuin moved 68.7% → 84.0% on
+   * CyberGym holding the model fixed, and agent-maintained TODO lists are a
+   * named component of that harness design.
+   *
+   * Default ON, on the same reasoning as `lootLedger` above: it is additive
+   * (one tool schema plus a size-capped block), it is structured state
+   * re-rendered per turn rather than a new search or reasoning layer, and the
+   * failure mode of an unused tool is a few hundred wasted schema tokens
+   * rather than wrong behavior. Note for whoever publishes benchmark numbers
+   * next: this DOES change the default tool list, so re-baseline before
+   * quoting a figure across this change. Disable via PWNKIT_FEATURE_AGENT_PLAN=0
+   * or `--features no-agent-plan` for ablation. Getter so the CLI `--features`
+   * flag (which sets the env var AFTER this module is imported) is honored at
+   * tool-dispatch time.
+   */
+  get agentPlan(): boolean {
+    return env("PWNKIT_FEATURE_AGENT_PLAN", false);
+  },
+
+  /**
+   * Task-drift detection (`packages/core/src/agent/drift.ts`).
+   *
+   * When ON, the loop tracks lexical "anchor contact" between each turn's
+   * activity and the objective + open plan tasks, and injects a re-anchoring
+   * message when contact has been absent for several consecutive turns. It is
+   * a pure function of the trajectory — no LLM call, no network, no per-turn
+   * cost. Complements `loopDetection`, which catches an agent repeating itself;
+   * drift is the opposite shape (novel activity every turn, none of it on-task)
+   * and is invisible to the loop detector.
+   *
+   * Default OFF, unlike `agentPlan` above, and the asymmetry is deliberate: the
+   * plan tool is a capability the model chooses to use, whereas this INJECTS
+   * unsolicited steering into a running agent based on a lexical heuristic
+   * whose false-positive rate has not been measured. The measurement needs
+   * labelled trajectories (replay stored benchmark runs, human-mark which fires
+   * were genuine derails) and that corpus does not exist yet — see the honest
+   * limitations section in the module doc, particularly that a legitimate pivot
+   * to a newly-discovered lead is lexically indistinguishable from a derail.
+   * Repo convention is explicit that behavior-steering features stay opt-in
+   * until A/B'd, and this is squarely one. Enable via
+   * PWNKIT_FEATURE_DRIFT_DETECTION=1 or `--features drift-detection`.
+   */
+  get driftDetection(): boolean {
+    return env("PWNKIT_FEATURE_DRIFT_DETECTION", false);
+  },
+
+  /**
    * OAST out-of-band interaction collaborator + oracle (#659).
    *
    * When ON, the attack/verify agents get `oast_register` / `oast_poll` to

--- a/packages/core/src/agent/native-loop.ts
+++ b/packages/core/src/agent/native-loop.ts
@@ -20,6 +20,8 @@ import { WafDetector } from "../scope/waf-detect.js";
 import { ToolExecutor, getToolsForRole } from "./tools.js";
 import { features } from "./features.js";
 import { LootLedger } from "./loot.js";
+import { TaskLedger } from "./task-ledger.js";
+import { DriftMonitor } from "./drift.js";
 import { createCollaborator } from "../oast/index.js";
 import {
   maybeCreateTrustGraphSession,
@@ -392,6 +394,32 @@ export async function runNativeAgentLoop(
   // results and re-injects a compact "known footholds" block each turn.
   const loot = features.lootLedger ? new LootLedger() : undefined;
 
+  // Typed TODO / plan ledger. Threaded through ToolContext so the `plan` tool
+  // reads and mutates it; the loop below re-injects a compact plan block
+  // re-rendered from the structured state (which is what makes the plan
+  // survive compaction) and feeds its open tasks to the drift monitor.
+  const plan = features.agentPlan ? new TaskLedger() : undefined;
+
+  // Task-drift monitor. Deterministic, no LLM call — see agent/drift.ts.
+  //
+  // The objective anchor is a BOUNDED PREFIX of the system prompt, not the
+  // whole thing, and that bound is load-bearing rather than a micro-
+  // optimisation. The attack system prompts run to thousands of words and
+  // enumerate every vulnerability class the engine knows (`SQLI_SECTION`,
+  // `XSS_SECTION`, …); feeding all of it in would put essentially every
+  // security term into the anchor set, anchor contact would then be true on
+  // every conceivable turn, and the detector would be silent forever. The
+  // opening lines carry the actual mission statement, so that is what anchors.
+  // In practice the OPEN PLAN is the dominant anchor source, which is the
+  // intended design: drift is measured against what the agent said it would do.
+  const OBJECTIVE_PREFIX_CHARS = 600;
+  const driftMonitor = features.driftDetection
+    ? new DriftMonitor({
+        objective: config.systemPrompt.slice(0, OBJECTIVE_PREFIX_CHARS),
+        target: config.target,
+      })
+    : undefined;
+
   // pwnkit#659 — hosted OAST interaction collaborator. Built only when the
   // feature is on AND a collaborator server is configured (PWNKIT_OAST_URL);
   // `createCollaborator` returns undefined otherwise, in which case the
@@ -447,6 +475,7 @@ export async function runNativeAgentLoop(
     attribution: config.attribution,
     engagement: config.engagement,
     loot,
+    plan,
     oast,
   };
 
@@ -620,8 +649,12 @@ export async function runNativeAgentLoop(
   // drop-oldest pruning, and the retry cap prevents an endless shrink loop.
   let contextOverflowRecoveries = 0;
 
-  // Dynamic playbook injection — only inject once per session
+  // Dynamic playbook injection. `playbookInjected` now only records that the
+  // FIRST injection has happened (for event labelling); the structured
+  // `injectedPlaybookTypes` list is what the block is re-rendered from, so the
+  // methodology can be restored after a compaction erases the message.
   let playbookInjected = false;
+  let injectedPlaybookTypes: string[] = [];
   const recentToolResultTexts: string[] = [];
 
   // pwnkit#567 — loot-injection cadence. Re-surface the "known footholds"
@@ -631,6 +664,11 @@ export async function runNativeAgentLoop(
   // away. -1 sentinels force a first injection as soon as loot exists.
   let lastInjectedLootRevision = -1;
   let lastLootInjectionTurn = -1;
+
+  // Plan-injection cadence, same sentinels and same contract as the loot pair
+  // above: -1 forces a first injection as soon as the agent records any task.
+  let lastInjectedPlanRevision = -1;
+  let lastPlanInjectionTurn = -1;
 
   // JIT skill tracking (#458): share the recentToolResultTexts buffer and
   // a persistent loadedSkills set with the ToolContext so skill tools can
@@ -744,6 +782,10 @@ export async function runNativeAgentLoop(
     }
 
     state.turnCount++;
+    // Keep the tool context's turn stamp fresh so tools that record state can
+    // date it (the plan ledger stamps createdTurn / updatedTurn, which is what
+    // makes a task that has sat untouched for 20 turns visible as stale).
+    toolCtx.currentTurn = state.turnCount;
     const turnStartedAt = Date.now();
     // Mutable inside the try-block; read in the finally to stamp
     // agent_turn_completed with the right exit reason. Reassigned by
@@ -1471,10 +1513,11 @@ export async function runNativeAgentLoop(
     // playbooks need them (pre-injection) OR JIT skills are enabled
     // (skill trigger matching needs the full history). The buffer is the
     // same array reference threaded into toolCtx (#458).
-    if (
-      (features.dynamicPlaybooks && !playbookInjected)
-      || features.jitSkills
-    ) {
+    // The playbook half of this condition used to stop filling the buffer once
+    // the one-shot injection had fired. Now that the injection can be re-
+    // evaluated (below), the buffer has to keep flowing so a class detected
+    // only after deeper recon can still be picked up.
+    if (features.dynamicPlaybooks || features.jitSkills) {
       for (const block of toolResultBlocks) {
         if (block.type === "tool_result") {
           recentToolResultTexts.push(block.content);
@@ -1486,25 +1529,58 @@ export async function runNativeAgentLoop(
     // ── Dynamic playbook injection at ~30% budget ──
     // After initial reconnaissance, pattern-match tool results to detect
     // vulnerability types and inject targeted methodology playbooks.
+    //
+    // This block used to be strictly one-shot: a `playbookInjected` latch fired
+    // once and the methodology then lived ONLY in the transcript. That made it
+    // the one piece of injected guidance that did not survive compaction — a
+    // `compactMessagesWithLLM` pass at turn ~25 could silently erase the
+    // playbook injected at turn 12, so the feature aimed at long runs lost its
+    // content precisely on long runs. Worse for evaluation: whether the
+    // methodology was present at the end of a run depended on whether a
+    // compaction happened to land after the injection turn, which means an A/B
+    // of this flag would partly be measuring compaction timing rather than the
+    // feature.
+    //
+    // Fix follows the loot / plan pattern — re-render from structured state
+    // (the detected type list) rather than trusting the message to survive —
+    // with one refinement. Loot and plan re-inject on a fixed turn interval and
+    // accept duplicate blocks; a playbook block is up to ~3.6k tokens, so
+    // periodic duplication would be a real context cost. Instead we re-inject
+    // only when the block is ABSENT from the live message window, which is a
+    // cheap deterministic check over a bounded array and re-injects exactly
+    // when compaction ate it — zero duplicates in the steady state. The default
+    // for `dynamicPlaybooks` is deliberately unchanged (still OFF); this makes
+    // the mechanism sound so a future A/B measures the feature itself.
     const playbookPct = state.turnCount / config.maxTurns;
     if (
       features.dynamicPlaybooks
-      && !playbookInjected
       && playbookPct >= 0.3
       && recentToolResultTexts.length > 0
     ) {
       const detectedTypes = detectPlaybooks(recentToolResultTexts);
-      if (detectedTypes.length > 0) {
+      // Re-inject when the class set changed (deeper recon revealed another
+      // vuln class) or when the block is no longer present in the window.
+      const typesChanged =
+        detectedTypes.join("|") !== injectedPlaybookTypes.join("|");
+      const needsReinject =
+        detectedTypes.length > 0
+        && (typesChanged || !messagesContainText(state.messages, PLAYBOOK_MARKER));
+      if (needsReinject) {
         const playbookText = buildPlaybookInjection(detectedTypes);
         if (playbookText) {
           state.messages.push({
             role: "user",
             content: [{ type: "text", text: playbookText }],
           });
+          const isFirstInjection = !playbookInjected;
           playbookInjected = true;
+          injectedPlaybookTypes = detectedTypes;
           onEvent?.("playbook_injected", {
             turn: state.turnCount,
             types: detectedTypes,
+            // Distinguishes the initial injection from a post-compaction
+            // restore so the two are separable in run analysis.
+            reason: isFirstInjection ? "initial" : typesChanged ? "types_changed" : "restored",
           });
           if (db) {
             db.logEvent({
@@ -1554,6 +1630,82 @@ export async function runNativeAgentLoop(
             eventType: "loot_injected",
             agentRole: config.role,
             payload: { turn: state.turnCount, count: loot.size, revision: loot.revision },
+            timestamp: Date.now(),
+          });
+        }
+      }
+    }
+
+    // ── Plan (TODO ledger) injection ──
+    // Same mechanism and the same reason as the loot block above: the plan is
+    // re-rendered from STRUCTURED STATE, so `compactMessagesWithLLM` summarizing
+    // away or dropping the message that carried it costs nothing — the next
+    // injection reproduces it exactly. A plan that lived only in the transcript
+    // would not survive, which is precisely the failure the external-memory
+    // scratchpad has today.
+    //
+    // Throttled on the same revision-or-interval rule, but with a longer
+    // interval: unlike loot (where a credential captured at turn 12 must stay
+    // in the recent window), an unchanged plan re-pushed every third turn is
+    // pure repetition. Revision changes still inject immediately, so a plan the
+    // agent is actively maintaining is always current in context.
+    const PLAN_REINJECT_INTERVAL = 6;
+    if (
+      plan
+      && plan.size > 0
+      && (plan.revision !== lastInjectedPlanRevision
+        || state.turnCount - lastPlanInjectionTurn >= PLAN_REINJECT_INTERVAL)
+    ) {
+      const planText = plan.render();
+      if (planText) {
+        state.messages.push({
+          role: "user",
+          content: [{ type: "text", text: planText }],
+        });
+        lastInjectedPlanRevision = plan.revision;
+        lastPlanInjectionTurn = state.turnCount;
+        onEvent?.("plan_injected", {
+          turn: state.turnCount,
+          open: plan.open().length,
+          total: plan.size,
+          revision: plan.revision,
+        });
+      }
+    }
+
+    // ── Task-drift detection ──
+    // Deliberately placed alongside loop detection because the two are
+    // complementary halves of "the agent has stopped making progress":
+    // `loopDetector` catches repetition (same call over and over), this catches
+    // divergence (novel activity every turn, none of it on-task). Neither sees
+    // the other's failure mode. Deterministic and free — see agent/drift.ts for
+    // the signal and, importantly, for what it cannot see.
+    if (driftMonitor) {
+      driftMonitor.record(toolCalls, plan?.openText() ?? "");
+      const driftWarning = driftMonitor.detect();
+      if (driftWarning) {
+        state.messages.push({
+          role: "user",
+          content: [{ type: "text", text: driftWarning }],
+        });
+        const driftState = driftMonitor.state;
+        onEvent?.("drift_detected", {
+          turn: state.turnCount,
+          streak: driftState.streak,
+          anchorSize: driftState.anchorSize,
+          warningsIssued: driftState.warningsIssued,
+        });
+        if (db) {
+          db.logEvent({
+            scanId: config.scanId,
+            stage: config.role,
+            eventType: "drift_detected",
+            agentRole: config.role,
+            payload: {
+              turn: state.turnCount,
+              streak: driftState.streak,
+              anchorSize: driftState.anchorSize,
+            },
             timestamp: Date.now(),
           });
         }
@@ -2263,6 +2415,39 @@ class LoopDetector {
 
     return null;
   }
+}
+
+/**
+ * Header of the dynamic-playbook block, used as a presence marker so the loop
+ * can tell whether the methodology is still in the live message window or was
+ * removed by a compaction pass. Must stay in sync with the header emitted by
+ * `buildPlaybookInjection` (agent/playbooks.ts) — `sop-flags.test.ts` asserts
+ * that they match, so a rename there fails loudly here rather than silently
+ * disabling the restore.
+ */
+export const PLAYBOOK_MARKER = "## Dynamic Playbook Injection";
+
+/**
+ * Whether any message in the window contains `needle`.
+ *
+ * Bounded and cheap: the window is the loop's own conversation array (kept
+ * small by compaction) and the scan short-circuits on the first hit. Deliberately
+ * a substring test on serialized text rather than structural matching, because
+ * the block can come back in two shapes — as the original standalone user
+ * message, or folded into a compaction summary by
+ * `features.preserveCriticalMessages` (playbook text is full of "password" /
+ * "admin" / "token", so it frequently trips the critical-message regex). Either
+ * shape means the methodology is still in front of the model, and neither
+ * warrants re-injecting it.
+ */
+function messagesContainText(messages: NativeMessage[], needle: string): boolean {
+  for (const msg of messages) {
+    for (const block of msg.content) {
+      if (block.type === "text" && block.text.includes(needle)) return true;
+      if (block.type === "tool_result" && block.content.includes(needle)) return true;
+    }
+  }
+  return false;
 }
 
 const LOOP_WARNING =

--- a/packages/core/src/agent/playbook-reinject.test.ts
+++ b/packages/core/src/agent/playbook-reinject.test.ts
@@ -1,0 +1,148 @@
+/**
+ * End-to-end test for playbook re-injection through a REAL in-loop compaction.
+ *
+ * The defect: playbook injection was one-shot (`playbookInjected` latch, single
+ * message push). The methodology lived only in the transcript, so a
+ * `compactMessagesWithLLM` pass could erase it and nothing ever put it back.
+ * Beyond losing the guidance, this contaminated evaluation — whether the
+ * feature's own content was present at the end of a run depended on whether a
+ * compaction happened to land after the injection turn, so an A/B of
+ * `dynamicPlaybooks` would partly have been measuring compaction timing.
+ *
+ * This drives `runNativeAgentLoop` for real: the agent runs `bash` (local, no
+ * network) emitting text that trips the SQLi indicators, the playbook is
+ * injected at the 30% checkpoint, token usage is scripted high enough to force
+ * a genuine compaction, and the loop is expected to notice the block is gone
+ * and restore it from structured state.
+ *
+ * `dynamicPlaybooks` stays OFF by default — this only makes the mechanism
+ * sound. The flag is enabled explicitly here and cleaned up after.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { runNativeAgentLoop, PLAYBOOK_MARKER } from "./native-loop.js";
+import type {
+  NativeRuntime,
+  NativeRuntimeResult,
+  NativeMessage,
+  NativeToolDef,
+} from "../runtime/types.js";
+
+/** Text that trips >= 2 SQLi indicators in `detectPlaybooks`. */
+const SQLI_ECHO =
+  "echo \"You have an error in your SQL syntax\"; " +
+  "echo \"mysql_fetch_array() expects parameter 1\"; " +
+  "echo \"SELECT * FROM users WHERE id=1\"";
+
+/**
+ * Mock runtime that always issues the same `bash` call and reports a large
+ * input-token count so the loop's compaction threshold (77k total, and >30k
+ * regrowth since the last compaction) is crossed mid-run.
+ */
+function createRuntime(perTurnInputTokens: number): NativeRuntime {
+  let n = 0;
+  return {
+    type: "api" as const,
+    async executeNative(
+      _system: string,
+      _messages: NativeMessage[],
+      _tools: NativeToolDef[],
+    ): Promise<NativeRuntimeResult> {
+      n += 1;
+      return {
+        content: [
+          { type: "tool_use", id: `tc-${n}`, name: "bash", input: { command: SQLI_ECHO } },
+        ],
+        stopReason: "tool_use",
+        durationMs: 1,
+        usage: { inputTokens: perTurnInputTokens, outputTokens: 10 },
+      };
+    },
+    async isAvailable() {
+      return true;
+    },
+  };
+}
+
+afterEach(() => {
+  delete process.env.PWNKIT_FEATURE_DYNAMIC_PLAYBOOKS;
+  delete process.env.PWNKIT_FEATURE_PRESERVE_CRITICAL_MESSAGES;
+});
+
+describe("dynamic playbook injection survives compaction", () => {
+  it("injects once, then restores the block after a real compaction erases it", async () => {
+    process.env.PWNKIT_FEATURE_DYNAMIC_PLAYBOOKS = "1";
+    // Playbook text is full of "password" / "admin" / "token", so the #229
+    // verbatim-preservation path would fold it into the compaction summary and
+    // mask the very defect under test. Disable it so the block is genuinely
+    // lost — that is the case the restore exists for.
+    process.env.PWNKIT_FEATURE_PRESERVE_CRITICAL_MESSAGES = "0";
+
+    const events: Array<{ type: string; payload: Record<string, unknown> }> = [];
+
+    const state = await runNativeAgentLoop({
+      config: {
+        role: "attack",
+        systemPrompt: "You are an attack agent testing a web application.",
+        tools: [],
+        maxTurns: 24,
+        target: "https://example.com",
+        scanId: "playbook-reinject-test",
+        // Early-stop would end the run at 50% before compaction can happen.
+        retryCount: 1,
+      },
+      runtime: createRuntime(20_000),
+      db: null,
+      onEvent: (type, payload) => {
+        events.push({ type, payload: payload as Record<string, unknown> });
+      },
+    });
+
+    const injections = events.filter((e) => e.type === "playbook_injected");
+    const compactions = events.filter((e) => e.type === "context_compacted");
+
+    // Preconditions: the run really did inject a playbook AND really did
+    // compact. Without both, the test proves nothing.
+    expect(injections.length).toBeGreaterThan(0);
+    expect(compactions.length).toBeGreaterThan(0);
+    expect(injections[0]?.payload.reason).toBe("initial");
+
+    // The point of the fix: at least one injection is a post-compaction
+    // restore, and the methodology is present in the final message window.
+    const restored = injections.filter((e) => e.payload.reason === "restored");
+    expect(restored.length).toBeGreaterThan(0);
+
+    expect(JSON.stringify(state.messages)).toContain(PLAYBOOK_MARKER);
+  }, 120_000);
+
+  it("does not re-inject while the block is still in the window", async () => {
+    process.env.PWNKIT_FEATURE_DYNAMIC_PLAYBOOKS = "1";
+
+    const events: Array<{ type: string; payload: Record<string, unknown> }> = [];
+
+    await runNativeAgentLoop({
+      config: {
+        role: "attack",
+        systemPrompt: "You are an attack agent testing a web application.",
+        tools: [],
+        maxTurns: 20,
+        target: "https://example.com",
+        scanId: "playbook-no-spam-test",
+        retryCount: 1,
+      },
+      // Low per-turn usage → never crosses the compaction threshold.
+      runtime: createRuntime(10),
+      db: null,
+      onEvent: (type, payload) => {
+        events.push({ type, payload: payload as Record<string, unknown> });
+      },
+    });
+
+    const injections = events.filter((e) => e.type === "playbook_injected");
+    // The regression this guards: a presence check that is always false would
+    // push ~3.6k tokens of methodology EVERY turn for the rest of the run.
+    // With no compaction, exactly one injection should ever happen.
+    expect(injections).toHaveLength(1);
+    expect(injections[0]?.payload.reason).toBe("initial");
+  }, 120_000);
+});

--- a/packages/core/src/agent/prompts.ts
+++ b/packages/core/src/agent/prompts.ts
@@ -113,6 +113,31 @@ a captured hash — then turn that access into a higher-severity finding. Call t
 truncate long ones) before you replay it in a request. The best findings come
 from combining footholds, not from single isolated probes.`;
 
+// Typed TODO ledger guidance. Appended to the attack-oriented system prompts,
+// flag-gated, mirroring LOOT_LEDGER_INSTRUCTION above. The ledger itself is
+// maintained by the `plan` tool and re-injected each turn by the agent loop;
+// this primes the agent to open with a plan rather than to start probing
+// immediately, which is the behaviour the tool exists to produce. Wording
+// leans on the one property the agent can verify for itself — the plan block
+// keeps reappearing — because a tool the model does not believe in is a tool
+// the model does not call.
+const PLAN_LEDGER_INSTRUCTION = `
+
+## Your plan
+
+Before your first probe, call \`plan\` with action='add' and put one task per
+line in \`title\` to lay out how you intend to approach this target. Then
+action='start' the task you are doing first.
+
+Keep it current as you work: \`complete\` a task the moment it is finished,
+\`drop\` it when you have ruled the approach out, \`add\` new tasks as leads
+appear, and \`start\` the one you are on so exactly one task is ever active. The
+plan is re-shown to you every turn, which makes it the one piece of state that
+survives your context being compacted — everything else in this conversation
+can be summarized away, so anything you want to still know in thirty turns
+belongs on the plan. An out-of-date plan is worse than no plan: if you are
+working on something that is not on the list, put it on the list first.`;
+
 // ---------------------------------------------------------------------------
 // Shared attack-technique sections  (#422)
 // ---------------------------------------------------------------------------
@@ -324,7 +349,7 @@ Only save findings where:
 1. The sink is reachable through a realistic, unintended attack path
 2. The attacker's input comes from a network-ingestion point (HTTP request body/query/header, file upload, user-supplied URL)
 3. The impact involves privilege escalation, data exfiltration, or lateral movement — not self-DoS
-4. The package's own documentation doesn't already warn about this usage${buildAuthPromptBlock(auth)}${featureFlags.externalMemory ? EXTERNAL_MEMORY_INSTRUCTION : ""}${featureFlags.lootLedger ? LOOT_LEDGER_INSTRUCTION : ""}`;
+4. The package's own documentation doesn't already warn about this usage${buildAuthPromptBlock(auth)}${featureFlags.externalMemory ? EXTERNAL_MEMORY_INSTRUCTION : ""}${featureFlags.lootLedger ? LOOT_LEDGER_INSTRUCTION : ""}${featureFlags.agentPlan ? PLAN_LEDGER_INSTRUCTION : ""}`;
 }
 
 export function webPentestPrompt(target: string, opts?: { hasBrowser?: boolean; auth?: AuthConfig }): string {
@@ -394,7 +419,7 @@ ${IDOR_SECTION}
 - Be thorough: test every input field and parameter you discover
 - Do NOT report missing security headers as critical/high — they are typically medium/low
 
-When done testing all categories, call the done tool with a summary of findings.${browserSection}${buildAuthPromptBlock(opts?.auth)}${featureFlags.externalMemory ? EXTERNAL_MEMORY_INSTRUCTION : ""}${featureFlags.lootLedger ? LOOT_LEDGER_INSTRUCTION : ""}`;
+When done testing all categories, call the done tool with a summary of findings.${browserSection}${buildAuthPromptBlock(opts?.auth)}${featureFlags.externalMemory ? EXTERNAL_MEMORY_INSTRUCTION : ""}${featureFlags.lootLedger ? LOOT_LEDGER_INSTRUCTION : ""}${featureFlags.agentPlan ? PLAN_LEDGER_INSTRUCTION : ""}`;
 }
 
 export function webPentestDiscoveryPrompt(target: string, auth?: AuthConfig): string {
@@ -533,7 +558,7 @@ When you find a vulnerability:
 10. Do NOT give up after one failed payload — try ALL variations.
 11. Call done with a summary when you have exhausted the realistic audit surface.
 
-If the target uses MongoDB-style 24-char hex IDs (ObjectIds) and you suspect an IDOR vulnerability, the \`mongo_objectid\` tool can forge IDs with arbitrary timestamp + counter. The 'first user' has counter 0 — copy the 5-byte machine ID from any observed ObjectId.${buildAuthPromptBlock(auth)}${featureFlags.externalMemory ? EXTERNAL_MEMORY_INSTRUCTION : ""}${featureFlags.lootLedger ? LOOT_LEDGER_INSTRUCTION : ""}${featureFlags.jitSkills ? SKILL_TOOL_HINT : ""}`;
+If the target uses MongoDB-style 24-char hex IDs (ObjectIds) and you suspect an IDOR vulnerability, the \`mongo_objectid\` tool can forge IDs with arbitrary timestamp + counter. The 'first user' has counter 0 — copy the 5-byte machine ID from any observed ObjectId.${buildAuthPromptBlock(auth)}${featureFlags.externalMemory ? EXTERNAL_MEMORY_INSTRUCTION : ""}${featureFlags.lootLedger ? LOOT_LEDGER_INSTRUCTION : ""}${featureFlags.agentPlan ? PLAN_LEDGER_INSTRUCTION : ""}${featureFlags.jitSkills ? SKILL_TOOL_HINT : ""}`;
 }
 
 export function verifyPrompt(target: string, findings: Finding[], auth?: AuthConfig): string {
@@ -968,7 +993,7 @@ observed in real scans and will fail the engagement if you fall into them:
 - **Repeat-payload trap**: If you've already sent a specific payload to a
   specific endpoint and it failed, do not send the same payload again
   later "to double-check". Mutate it or move on.
-${scriptSection}${featureFlags.externalMemory ? EXTERNAL_MEMORY_INSTRUCTION : ""}${featureFlags.lootLedger ? LOOT_LEDGER_INSTRUCTION : ""}${featureFlags.jitSkills ? SKILL_TOOL_HINT : ""}
+${scriptSection}${featureFlags.externalMemory ? EXTERNAL_MEMORY_INSTRUCTION : ""}${featureFlags.lootLedger ? LOOT_LEDGER_INSTRUCTION : ""}${featureFlags.agentPlan ? PLAN_LEDGER_INSTRUCTION : ""}${featureFlags.jitSkills ? SKILL_TOOL_HINT : ""}
 ## Rules
 - Read ALL response headers and cookies after every request
 - Log in FIRST if there is a login form

--- a/packages/core/src/agent/sop-flags.test.ts
+++ b/packages/core/src/agent/sop-flags.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Flag-boundary tests for the SOP surfaces: dynamic playbooks and the `plan`
+ * tool.
+ *
+ * These exist because every one of these features is a getter reading an env
+ * var at call time (so the CLI `--features` flag, which mutates the env AFTER
+ * this module is imported, is honored). That pattern is easy to regress into a
+ * const, at which point the flag silently stops working — and a silently
+ * ignored feature flag is worse than no flag, because ablation runs would
+ * report a difference that was never applied.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { features } from "./features.js";
+import { detectPlaybooks, buildPlaybookInjection, PLAYBOOKS } from "./playbooks.js";
+import { getToolsForRole, TOOL_DEFINITIONS } from "./tools.js";
+
+const TOUCHED_ENV = [
+  "PWNKIT_FEATURE_DYNAMIC_PLAYBOOKS",
+  "PWNKIT_FEATURE_AGENT_PLAN",
+  "PWNKIT_FEATURE_DRIFT_DETECTION",
+];
+
+afterEach(() => {
+  for (const key of TOUCHED_ENV) delete process.env[key];
+});
+
+describe("feature-flag boundaries", () => {
+  it("dynamicPlaybooks defaults OFF and honors a late env mutation", () => {
+    expect(features.dynamicPlaybooks).toBe(false);
+    process.env.PWNKIT_FEATURE_DYNAMIC_PLAYBOOKS = "1";
+    expect(features.dynamicPlaybooks).toBe(true);
+    process.env.PWNKIT_FEATURE_DYNAMIC_PLAYBOOKS = "0";
+    expect(features.dynamicPlaybooks).toBe(false);
+  });
+
+  it("agentPlan defaults OFF and can be opted into", () => {
+    // Default OFF per the features.ts convention: the plan tool adds a tool to
+    // every scan's tool list, a system-prompt block and a per-turn injected
+    // block. That changes agent behaviour, so it must be A/B'd before it
+    // ships on — and shipping it on would silently invalidate every existing
+    // benchmark baseline.
+    expect(features.agentPlan).toBe(false);
+    process.env.PWNKIT_FEATURE_AGENT_PLAN = "1";
+    expect(features.agentPlan).toBe(true);
+  });
+
+  it("driftDetection defaults OFF and can be opted into", () => {
+    expect(features.driftDetection).toBe(false);
+    process.env.PWNKIT_FEATURE_DRIFT_DETECTION = "1";
+    expect(features.driftDetection).toBe(true);
+  });
+});
+
+describe("`plan` tool exposure follows the agentPlan flag", () => {
+  it("is offered to the attack role when on and withheld when off", () => {
+    process.env.PWNKIT_FEATURE_AGENT_PLAN = "1";
+    const on = getToolsForRole("attack").map((t) => t.name);
+    expect(on).toContain("plan");
+
+    process.env.PWNKIT_FEATURE_AGENT_PLAN = "0";
+    const off = getToolsForRole("attack").map((t) => t.name);
+    expect(off).not.toContain("plan");
+  });
+
+  it("is kept out of the audit/review everything-set when off", () => {
+    // Regression guard matching the use_loot / JIT-skill gating: tools that
+    // enumerate Object.keys(TOOL_DEFINITIONS) would otherwise leak `plan` into
+    // roles regardless of the flag.
+    process.env.PWNKIT_FEATURE_AGENT_PLAN = "0";
+    for (const role of ["audit", "review"]) {
+      expect(getToolsForRole(role).map((t) => t.name)).not.toContain("plan");
+    }
+    process.env.PWNKIT_FEATURE_AGENT_PLAN = "1";
+    for (const role of ["audit", "review"]) {
+      expect(getToolsForRole(role).map((t) => t.name)).toContain("plan");
+    }
+  });
+
+  it("declares a schema whose required set matches the discriminated union", () => {
+    const def = TOOL_DEFINITIONS.plan;
+    expect(def).toBeDefined();
+    // `action` is the only unconditionally-required field; everything else is
+    // conditional on the action and is enforced by Zod, not by the schema.
+    expect(def?.required).toEqual(["action"]);
+    expect(def?.parameters.action?.enum).toEqual([
+      "add",
+      "start",
+      "complete",
+      "drop",
+      "note",
+      "list",
+    ]);
+  });
+});
+
+describe("playbook injection behavior at the flag boundary", () => {
+  /**
+   * The flag gates the CALL SITE (native-loop.ts), not these functions — they
+   * are pure and always work. What is asserted here is the contract the call
+   * site depends on: detection needs >=2 indicator hits, caps at 3 playbooks,
+   * and returns empty (so the loop injects nothing) when nothing matches.
+   */
+  it("returns nothing to inject when tool output matches no indicators", () => {
+    const types = detectPlaybooks(["200 OK", "hello world", "<h1>Welcome</h1>"]);
+    expect(types).toEqual([]);
+    expect(buildPlaybookInjection(types)).toBe("");
+  });
+
+  it("requires two indicator hits, not one", () => {
+    // A single SQL-flavored string is not enough to commit 500+ tokens of
+    // methodology to the context.
+    const single = detectPlaybooks(["You have an error in your SQL syntax"]);
+    expect(single).not.toContain("sqli");
+  });
+
+  it("detects a class from richer evidence and builds an injection for it", () => {
+    const types = detectPlaybooks([
+      "You have an error in your SQL syntax near '1''",
+      "mysql_fetch_array() expects parameter 1",
+      "SELECT * FROM users WHERE id=",
+    ]);
+    expect(types.length).toBeGreaterThan(0);
+    const text = buildPlaybookInjection(types);
+    expect(text).toContain("Dynamic Playbook Injection");
+    expect(text).toContain(PLAYBOOKS[types[0]!]);
+  });
+
+  it("caps at three playbooks so the injection stays bounded", () => {
+    // Feed evidence for many classes at once; the cap is what keeps the
+    // worst-case injection size predictable.
+    const kitchenSink = [
+      "You have an error in your SQL syntax",
+      "mysql_fetch_array() expects parameter 1",
+      "<script>alert(1)</script> reflected in response",
+      "Content-Type: text/html; charset=utf-8",
+      "{{7*7}} rendered as 49",
+      "jinja2.exceptions.TemplateSyntaxError",
+      "/api/users/1 returned another user's record",
+      "id parameter changed to 2 returned 200 OK",
+      "failed to open stream: /etc/passwd",
+      "include(): Failed opening required",
+    ];
+    expect(detectPlaybooks(kitchenSink).length).toBeLessThanOrEqual(3);
+  });
+
+  it("keeps the worst-case injection inside a predictable context budget", () => {
+    // Guards the cost side of the default-ON question: if someone adds a
+    // 20k-character playbook, the top-3 injection silently doubles the
+    // context cost of every scan that trips it.
+    const sizes = Object.values(PLAYBOOKS)
+      .map((p) => p.length)
+      .sort((a, b) => b - a);
+    const worstCaseChars = sizes.slice(0, 3).reduce((a, b) => a + b, 0);
+    // ~4 chars/token → ~3.6k tokens today. The assertion is a ratchet, not a
+    // measurement: it fails loudly if the worst case grows a lot.
+    expect(worstCaseChars).toBeLessThan(20_000);
+  });
+});

--- a/packages/core/src/agent/task-ledger.test.ts
+++ b/packages/core/src/agent/task-ledger.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Tests for the typed TODO / plan ledger.
+ *
+ * The bar these are written to: the plan's whole value proposition is that it
+ * is STRUCTURED state that is re-rendered rather than transcript text that is
+ * hoped to survive. So the load-bearing test is the compaction one — everything
+ * else is guarding the invariants that make the ledger a useful drift anchor
+ * (single active task, closed tasks stop anchoring, malformed input rejected
+ * rather than silently swallowed).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  TaskLedger,
+  applyPlanAction,
+  validatePlanArgs,
+  MAX_PLAN_TASKS,
+  MAX_TITLE_LEN,
+} from "./task-ledger.js";
+import { compactMessagesWithLLM } from "./native-loop.js";
+import type { NativeMessage, NativeRuntime } from "./types.js";
+
+describe("TaskLedger — basics", () => {
+  it("adds a task and returns it as open and pending", () => {
+    const ledger = new TaskLedger();
+    const res = ledger.add("Probe /login for SQLi", undefined, 1);
+    expect(res.ok).toBe(true);
+    expect(ledger.size).toBe(1);
+    const [task] = ledger.open();
+    expect(task?.id).toBe("task-1");
+    expect(task?.status).toBe("pending");
+    expect(task?.createdTurn).toBe(1);
+  });
+
+  it("bulk-adds one task per line, stripping list markers", () => {
+    const ledger = new TaskLedger();
+    const res = ledger.add(
+      "- Enumerate endpoints\n2. Test auth bypass\n* Check file upload",
+      undefined,
+      1,
+    );
+    expect(res.ok).toBe(true);
+    expect(ledger.size).toBe(3);
+    expect(ledger.open().map((t) => t.title)).toEqual([
+      "Enumerate endpoints",
+      "Test auth bypass",
+      "Check file upload",
+    ]);
+  });
+
+  it("attaches a shared detail only on a single-line add", () => {
+    const single = new TaskLedger();
+    single.add("Test IDOR", "increment user_id on /api/users", 1);
+    expect(single.open()[0]?.detail).toBe("increment user_id on /api/users");
+
+    // On a bulk add the detail cannot be attributed to a specific task, so it
+    // is dropped rather than smeared across all of them.
+    const bulk = new TaskLedger();
+    bulk.add("Task A\nTask B", "some detail", 1);
+    expect(bulk.open().every((t) => t.detail === undefined)).toBe(true);
+  });
+
+  it("skips duplicate titles case- and whitespace-insensitively", () => {
+    const ledger = new TaskLedger();
+    ledger.add("Test SQLi on login", undefined, 1);
+    const res = ledger.add("test   sqli   ON LOGIN", undefined, 2);
+    expect(res.ok).toBe(false);
+    expect(ledger.size).toBe(1);
+  });
+
+  it("truncates an over-long title rather than rejecting it", () => {
+    const ledger = new TaskLedger();
+    ledger.add("x".repeat(MAX_TITLE_LEN + 200), undefined, 1);
+    const title = ledger.open()[0]?.title ?? "";
+    expect(title.length).toBeLessThan(MAX_TITLE_LEN + 40);
+    expect(title).toContain("truncated");
+  });
+
+  it("caps the plan at MAX_PLAN_TASKS", () => {
+    const ledger = new TaskLedger();
+    for (let i = 0; i < MAX_PLAN_TASKS; i++) {
+      ledger.add(`Task number ${i}`, undefined, 1);
+    }
+    const res = ledger.add("One too many", undefined, 2);
+    expect(res.ok).toBe(false);
+    expect(ledger.size).toBe(MAX_PLAN_TASKS);
+  });
+});
+
+describe("TaskLedger — the single-active invariant", () => {
+  it("demotes the previously active task when another is started", () => {
+    const ledger = new TaskLedger();
+    ledger.add("Task A\nTask B", undefined, 1);
+    ledger.start("task-1", 2);
+    expect(ledger.activeTask()?.id).toBe("task-1");
+
+    ledger.start("task-2", 3);
+    expect(ledger.activeTask()?.id).toBe("task-2");
+    expect(ledger.get("task-1")?.status).toBe("pending");
+    // Exactly one active, always — this is what gives drift a reference point.
+    expect(ledger.all().filter((t) => t.status === "active")).toHaveLength(1);
+  });
+
+  it("refuses to restart a closed task and names the reason", () => {
+    const ledger = new TaskLedger();
+    ledger.add("Task A", undefined, 1);
+    ledger.complete("task-1", undefined, 2);
+    const res = ledger.start("task-1", 3);
+    expect(res.ok).toBe(false);
+    expect(res.ok ? "" : res.error).toContain("already done");
+  });
+
+  it("returns known ids when given an unknown one so the model can correct", () => {
+    const ledger = new TaskLedger();
+    ledger.add("Task A", undefined, 1);
+    const res = ledger.start("task-99", 2);
+    expect(res.ok).toBe(false);
+    expect(res.ok ? "" : res.error).toContain("task-1");
+  });
+});
+
+describe("TaskLedger — closed tasks stop anchoring", () => {
+  it("drops completed and dropped tasks out of open() and openText()", () => {
+    const ledger = new TaskLedger();
+    ledger.add("Probe graphql introspection\nBrute force admin panel", undefined, 1);
+    expect(ledger.open()).toHaveLength(2);
+    expect(ledger.openText()).toContain("graphql");
+
+    ledger.complete("task-1", undefined, 5);
+    expect(ledger.open()).toHaveLength(1);
+    // The completed task must stop contributing anchor terms immediately —
+    // otherwise finished work keeps suppressing drift forever.
+    expect(ledger.openText()).not.toContain("graphql");
+
+    ledger.drop("task-2", "ruled out, no admin panel exists", 6);
+    expect(ledger.open()).toHaveLength(0);
+    expect(ledger.openText()).toBe("");
+  });
+
+  it("distinguishes done from dropped in the rendered block", () => {
+    const ledger = new TaskLedger();
+    ledger.add("Task A\nTask B\nTask C", undefined, 1);
+    ledger.complete("task-1", undefined, 2);
+    ledger.drop("task-2", undefined, 3);
+    expect(ledger.render()).toContain("1 done, 1 dropped");
+  });
+});
+
+describe("TaskLedger — revision semantics", () => {
+  it("bumps on every accepted mutation", () => {
+    const ledger = new TaskLedger();
+    expect(ledger.revision).toBe(0);
+    ledger.add("Task A", undefined, 1);
+    expect(ledger.revision).toBe(1);
+    ledger.start("task-1", 2);
+    expect(ledger.revision).toBe(2);
+    ledger.note("task-1", "found a candidate param", 3);
+    expect(ledger.revision).toBe(3);
+    ledger.complete("task-1", undefined, 4);
+    expect(ledger.revision).toBe(4);
+  });
+
+  it("does NOT bump on a rejected mutation or on a read", () => {
+    const ledger = new TaskLedger();
+    ledger.add("Task A", undefined, 1);
+    const before = ledger.revision;
+
+    ledger.start("task-404", 2); // rejected
+    expect(ledger.revision).toBe(before);
+
+    // `list` is a read: a model polling it must not be able to force the plan
+    // block to re-inject every single turn.
+    applyPlanAction(ledger, { action: "list" }, 3);
+    expect(ledger.revision).toBe(before);
+  });
+});
+
+describe("validatePlanArgs — reject malformed, name the field", () => {
+  it("accepts well-formed payloads for every action", () => {
+    expect(validatePlanArgs({ action: "add", title: "Probe login" }).ok).toBe(true);
+    expect(validatePlanArgs({ action: "start", id: "task-1" }).ok).toBe(true);
+    expect(validatePlanArgs({ action: "complete", id: "task-1" }).ok).toBe(true);
+    expect(validatePlanArgs({ action: "drop", id: "task-1" }).ok).toBe(true);
+    expect(validatePlanArgs({ action: "note", id: "task-1", detail: "x" }).ok).toBe(true);
+    expect(validatePlanArgs({ action: "list" }).ok).toBe(true);
+  });
+
+  it("rejects an unknown action", () => {
+    const res = validatePlanArgs({ action: "obliterate", id: "task-1" });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects add without a title and start without an id", () => {
+    const noTitle = validatePlanArgs({ action: "add" });
+    expect(noTitle.ok).toBe(false);
+    expect(noTitle.ok ? "" : noTitle.error).toContain("title");
+
+    const noId = validatePlanArgs({ action: "start" });
+    expect(noId.ok).toBe(false);
+    expect(noId.ok ? "" : noId.error).toContain("id");
+  });
+
+  it("rejects note without a detail (the whole point of the action)", () => {
+    const res = validatePlanArgs({ action: "note", id: "task-1" });
+    expect(res.ok).toBe(false);
+  });
+
+  it("strips unknown top-level keys instead of propagating them", () => {
+    const res = validatePlanArgs({
+      action: "add",
+      title: "Probe login",
+      tasks: [{ evil: true }],
+      status: "done",
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.args).not.toHaveProperty("tasks");
+      expect(res.args).not.toHaveProperty("status");
+    }
+  });
+
+  it("returns an error that names the valid shapes so the model can self-correct", () => {
+    const res = validatePlanArgs({ action: "add" });
+    expect(res.ok).toBe(false);
+    expect(res.ok ? "" : res.error).toContain("action:\"add\"");
+  });
+});
+
+describe("plan state survives a context-compaction cycle", () => {
+  /**
+   * This is the test the whole design exists to pass.
+   *
+   * `compactMessagesWithLLM` replaces the middle of the conversation with an
+   * LLM summary. If the plan lived only in the transcript — the way the
+   * external-memory scratchpad effectively does — it would be gone after
+   * compaction. Because it is re-rendered from the TaskLedger, the block the
+   * loop injects on the next turn is byte-identical to the one that was eaten.
+   *
+   * The runtime is stubbed with a summary that deliberately mentions NONE of
+   * the plan's content, so the assertion cannot pass by accident via the
+   * summary happening to echo the tasks back.
+   *
+   * The task wording is chosen to defeat BOTH of compaction's verbatim-
+   * preservation paths, so that the message really is gone and the re-render is
+   * genuinely the only thing that saves the plan:
+   *
+   *  - `CRITICAL_MESSAGE_PATTERNS` (flag / password / credential / cookie /
+   *    token / session / admin / root / secret / api_key / bearer / jwt), used
+   *    by `features.preserveCriticalMessages`, which is ON by default.
+   *  - `SUMMARY_EXTRACT_PATTERNS`, whose `/\/[\w/.-]{3,}/` rule copies any line
+   *    containing a URL path into the summary's "additional extracted context".
+   *    An earlier draft of this test used "/graphql" and "/upload" as task
+   *    titles and passed for that reason rather than the intended one.
+   *
+   * Worth stating plainly: real plans usually DO contain endpoints and
+   * auth-flavored words, so in production the plan block often survives
+   * compaction incidentally through those two paths. That is a happy accident
+   * the design must not lean on — hence a test that removes it.
+   */
+  it("re-renders an identical plan block after compaction drops the message", async () => {
+    const ledger = new TaskLedger();
+    ledger.add(
+      "Enumerate the newsletter signup form fields\nCompare pagination parameters on the catalogue listing",
+      undefined,
+      2,
+    );
+    ledger.start("task-2", 4);
+    ledger.note("task-2", "the sort parameter appears unfiltered", 5);
+
+    const planBlockBefore = ledger.render();
+    expect(planBlockBefore).toContain("task-2");
+    expect(planBlockBefore).toContain("the sort parameter appears unfiltered");
+
+    // compactMessagesWithLLM preserves messages[0] and the last 10, so the
+    // conversation must exceed 12 messages for anything to be compacted at
+    // all, and the plan block has to sit in the middle slice to be at risk.
+    const filler = (i: number): NativeMessage[] => [
+      { role: "assistant", content: [{ type: "text", text: `Probing step ${i}.` }] },
+      { role: "user", content: [{ type: "text", text: `tool results ${i}` }] },
+    ];
+    const messages: NativeMessage[] = [
+      { role: "user", content: [{ type: "text", text: "Start the engagement." }] },
+      { role: "assistant", content: [{ type: "text", text: "Recon first." }] },
+      // The plan block as it was injected into the live conversation.
+      { role: "user", content: [{ type: "text", text: planBlockBefore }] },
+      ...filler(1),
+      ...filler(2),
+      ...filler(3),
+      ...filler(4),
+      ...filler(5),
+      ...filler(6),
+    ];
+    expect(messages.length).toBeGreaterThan(12);
+
+    const runtime = {
+      executeNative: vi.fn().mockResolvedValue({
+        content: [
+          {
+            type: "text",
+            text: "The agent performed reconnaissance and issued a number of HTTP requests against the service. Nothing conclusive yet.",
+          },
+        ],
+        usage: { inputTokens: 10, outputTokens: 10 },
+      }),
+    } as unknown as NativeRuntime;
+
+    const compacted = await compactMessagesWithLLM(messages, runtime, "system prompt");
+
+    // Precondition for the test to mean anything: compaction really did remove
+    // the message that carried the plan.
+    const survivingText = JSON.stringify(compacted);
+    expect(survivingText).not.toContain("the sort parameter appears unfiltered");
+    expect(survivingText).not.toContain("newsletter signup form");
+
+    // The ledger is untouched by compaction, so the next injection reproduces
+    // the exact same block. That is what "survives compaction" means here.
+    expect(ledger.render()).toBe(planBlockBefore);
+    expect(ledger.activeTask()?.id).toBe("task-2");
+    expect(ledger.open()).toHaveLength(2);
+  });
+});
+
+describe("render()", () => {
+  it("marks the active task and returns empty for an empty ledger", () => {
+    const ledger = new TaskLedger();
+    expect(ledger.render()).toBe("");
+
+    ledger.add("Task A\nTask B", undefined, 1);
+    ledger.start("task-2", 2);
+    const out = ledger.render();
+    expect(out).toContain("▶ [task-2]");
+    expect(out).toContain("· [task-1]");
+  });
+
+  it("summarizes overflow instead of listing every open task", () => {
+    const ledger = new TaskLedger();
+    for (let i = 0; i < 20; i++) ledger.add(`Task number ${i}`, undefined, 1);
+    const out = ledger.render({ limit: 5 });
+    expect(out).toContain("and 15 more open");
+  });
+});

--- a/packages/core/src/agent/task-ledger.ts
+++ b/packages/core/src/agent/task-ledger.ts
@@ -1,0 +1,498 @@
+/**
+ * Typed TODO / plan ledger for long-horizon agent runs.
+ *
+ * Background — the engine had no representation of "what am I supposed to be
+ * doing". The closest thing was `features.externalMemory` (default OFF), which
+ * tells the agent to `echo` a JSON blob containing a free-text `"plan"` field
+ * to a file (`agent/prompts.ts` EXTERNAL_MEMORY_INSTRUCTION) that is re-read
+ * only at the >=30% reflection checkpoints, and only on turns where the model
+ * emitted no tool calls at all (`buildContinuePrompt` → `readExternalMemory`).
+ * Nothing parses it, nothing validates it, nothing notices when it goes stale,
+ * and nothing can compare it against what the agent is actually doing. It is a
+ * scratchpad, not a task list.
+ *
+ * Why this matters enough to add state: the cleanest controlled result in the
+ * agentic-exploitation field right now is Tencent Xuanwu's Atuin, which moved
+ * 68.7% → 84.0% on CyberGym holding the model FIXED (GLM-5.2) — the entire
+ * delta came from harness design, and a named component of that design is that
+ * agents maintain TODO lists which a workflow hook watches for task drift. A
+ * tracked task list is also the only thing that makes drift *detectable*: you
+ * cannot measure divergence from an objective that was never written down.
+ * `agent/drift.ts` consumes this ledger for exactly that.
+ *
+ * Design follows `agent/loot.ts` (the LootLedger, pwnkit#567) deliberately,
+ * because that module already solved the hard part of this problem in this
+ * codebase: it is a typed, deduped, size-capped store carrying a monotonic
+ * `revision`, and the agent loop re-renders a compact block from the STRUCTURED
+ * STATE each turn rather than hoping the original message survives. That is
+ * what makes it compaction-proof — `compactMessagesWithLLM` may summarize away
+ * or drop the message that carried the plan, and the next turn simply re-renders
+ * the identical block from `TaskLedger.render()`. Anything that lived only in
+ * the transcript would be gone. Matching the LootLedger shape (same `revision`
+ * getter, same `render({ limit })` signature, same "created only when the flag
+ * is on, threaded through ToolContext" wiring) also means the loop's injection
+ * throttle is the same code shape in both places.
+ *
+ * Two deliberate constraints, both of which exist to serve drift detection
+ * rather than to be tidy for their own sake:
+ *
+ * 1. **At most one task is `active` at a time.** Starting task B automatically
+ *    demotes an active task A back to `pending`. Without this the "current
+ *    objective" is a set rather than a point, and "is the agent still working
+ *    the assigned task" stops having an answer — every activity matches
+ *    *something* in a five-way-active plan, so drift can never fire. It also
+ *    reflects how the work actually runs: the loop is a single serial agent.
+ * 2. **Tasks are typed and validated, never free text.** Every mutation goes
+ *    through `applyPlanAction`, which parses against a Zod discriminated union
+ *    and returns a rejection the loop hands straight back to the model as an
+ *    `is_error` tool result so it can self-correct. This is the structured-
+ *    output discipline `agent/AGENTS.md` §1 mandates for any agent-facing
+ *    submission tool (the `kernel_run` / `kernelRunArgsSchema` pattern).
+ *
+ * The ledger is single-scan lifetime and in-memory, like the LootLedger. It is
+ * not written to the findings DB: a plan is working state, not a scan artifact,
+ * and persisting it would create a second, competing notion of scan progress
+ * next to the execution journal (`agent/journal/`). Runs that resume from the
+ * journal rebuild their plan the same way they rebuild everything else — by
+ * re-reading the rehydrated conversation.
+ */
+
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+
+/**
+ * Lifecycle state of a planned task. Closed on purpose — four states is the
+ * minimum that distinguishes "not started" from "being worked right now"
+ * (which drift detection needs) and "finished" from "deliberately abandoned"
+ * (which matters because an abandoned task must stop anchoring drift, while a
+ * completed one is evidence of progress).
+ */
+export type PlanTaskStatus = "pending" | "active" | "done" | "dropped";
+
+export interface PlanTask {
+  /** Short stable id, e.g. `task-3`. Stable for the ledger's lifetime. */
+  id: string;
+  /** Internal UUID (parity with Finding / LootItem; not surfaced to the model). */
+  uuid: string;
+  /** One-line statement of the task. Always present, always non-empty. */
+  title: string;
+  /** Optional longer note: the concrete approach, the endpoint, the payload. */
+  detail?: string;
+  status: PlanTaskStatus;
+  /** Agent turn the task was created on. */
+  createdTurn: number;
+  /** Agent turn of the most recent mutation (status change, retitle, note). */
+  updatedTurn: number;
+}
+
+/** A task considered "open" — still anchoring what the agent should be doing. */
+export type OpenPlanTask = PlanTask & { status: "pending" | "active" };
+
+// ── Tunables ──────────────────────────────────────────────────────────────
+
+/**
+ * Hard cap on tasks. A plan longer than this is not a plan, it is a second
+ * transcript — and it would dominate the per-turn injected block, which is the
+ * cost this whole feature is trying to keep bounded.
+ */
+export const MAX_PLAN_TASKS = 40;
+/** Titles longer than this are truncated (with a marker). */
+export const MAX_TITLE_LEN = 200;
+/** Details longer than this are truncated (with a marker). */
+export const MAX_DETAIL_LEN = 600;
+/** Bulk-add via a newline-separated title accepts at most this many lines. */
+export const MAX_BULK_ADD = 12;
+/** How many tasks the injected block renders by default. */
+const DEFAULT_RENDER_LIMIT = 15;
+/** Titles shorter than this are rejected — not a task, a typo. */
+const MIN_TITLE_LEN = 3;
+
+const TRUNCATION_MARKER = "…[truncated]";
+
+function clamp(value: string, max: number): string {
+  const v = value.trim();
+  return v.length <= max ? v : v.slice(0, max) + TRUNCATION_MARKER;
+}
+
+/** Normalized dedup key so the model can't add the same task five times. */
+function dedupKey(title: string): string {
+  return title.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+// ── Tool-argument schema (agent/AGENTS.md §1: validate, reject malformed) ──
+
+/**
+ * The `plan` tool is a single tool with an `action` discriminator rather than
+ * five separate tools (`plan_add`, `plan_start`, …). Five tools would cost five
+ * schemas in every request's tool list for one concept, and models handle a
+ * small closed `action` enum reliably. The union is discriminated so an
+ * `action: "start"` missing an `id` is rejected with a message naming the
+ * missing field, instead of silently no-oping.
+ *
+ * Every branch `.strip()`s unknown keys by default (Zod object default), which
+ * matters for the same defense-in-depth reason `kernelRunArgsSchema` does it:
+ * models routinely emit adjacent fields (`tasks`, `items`, `status`) that must
+ * not reach the ledger.
+ */
+export const planActionSchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("add"),
+    title: z.string().min(MIN_TITLE_LEN, `title must be at least ${MIN_TITLE_LEN} characters`),
+    detail: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal("start"),
+    id: z.string().min(1, "id is required (e.g. 'task-2')"),
+  }),
+  z.object({
+    action: z.literal("complete"),
+    id: z.string().min(1, "id is required (e.g. 'task-2')"),
+    detail: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal("drop"),
+    id: z.string().min(1, "id is required (e.g. 'task-2')"),
+    detail: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal("note"),
+    id: z.string().min(1, "id is required (e.g. 'task-2')"),
+    detail: z.string().min(1, "detail is required for action 'note'"),
+  }),
+  z.object({ action: z.literal("list") }),
+]);
+
+export type PlanAction = z.infer<typeof planActionSchema>;
+
+/**
+ * Result of validating a raw `plan` tool payload. Mirrors
+ * `validateKernelRunArgs`' discriminated `{ ok, ... }` union so the call site
+ * can feed a rejection straight back as an `is_error` tool result.
+ */
+export type PlanArgsValidation =
+  | { ok: true; args: PlanAction }
+  | { ok: false; error: string };
+
+export function validatePlanArgs(raw: unknown): PlanArgsValidation {
+  const parsed = planActionSchema.safeParse(raw);
+  if (parsed.success) return { ok: true, args: parsed.data };
+  // Flatten to one actionable line — the model gets this back verbatim, so it
+  // needs to name the field, not dump a nested Zod tree.
+  const issues = parsed.error.issues
+    .map((i) => `${i.path.join(".") || "action"}: ${i.message}`)
+    .join("; ");
+  return {
+    ok: false,
+    error:
+      `Invalid plan arguments — ${issues}. ` +
+      `Valid shapes: {action:"add", title, detail?}, {action:"start"|"complete"|"drop", id}, ` +
+      `{action:"note", id, detail}, {action:"list"}.`,
+  };
+}
+
+/** Outcome of a validated mutation. `error` is model-facing prose. */
+export type PlanMutation =
+  | { ok: true; tasks: PlanTask[]; message: string }
+  | { ok: false; error: string };
+
+// ── Ledger ────────────────────────────────────────────────────────────────
+
+/**
+ * Typed store of the agent's plan. Single-scan lifetime; created by the agent
+ * loop when `features.agentPlan` is on and threaded through `ToolContext` so
+ * the `plan` tool can read and write it, exactly as `LootLedger` is threaded
+ * for `use_loot`.
+ */
+export class TaskLedger {
+  private tasks: PlanTask[] = [];
+  private byId = new Map<string, PlanTask>();
+  private seen = new Set<string>();
+  private counter = 0;
+  private _revision = 0;
+
+  /** Total tasks in the ledger, including completed and dropped. */
+  get size(): number {
+    return this.tasks.length;
+  }
+
+  /**
+   * Monotonic revision — bumps on every accepted mutation. The loop compares it
+   * against the last injected revision to decide whether the plan block in the
+   * agent's context is stale. Same contract as `LootLedger.revision`.
+   */
+  get revision(): number {
+    return this._revision;
+  }
+
+  /** All tasks in creation order. */
+  all(): readonly PlanTask[] {
+    return this.tasks;
+  }
+
+  /** Tasks still anchoring the agent's work: `pending` or `active`. */
+  open(): OpenPlanTask[] {
+    return this.tasks.filter(
+      (t): t is OpenPlanTask => t.status === "pending" || t.status === "active",
+    );
+  }
+
+  /** The single in-progress task, if one has been started. */
+  activeTask(): PlanTask | undefined {
+    return this.tasks.find((t) => t.status === "active");
+  }
+
+  get(id: string): PlanTask | undefined {
+    return this.byId.get(id);
+  }
+
+  /**
+   * Add one task, or several when `title` carries newlines (models like to lay
+   * out an entire opening plan in a single call, and the shared `ToolParam`
+   * type has no array kind — widening it would touch every provider adapter for
+   * no behavioural gain). Duplicate titles are skipped rather than rejected: a
+   * re-stated plan is a normal thing for a model to emit, and failing the whole
+   * call because line 3 of 6 repeats an existing task would be hostile.
+   */
+  add(rawTitle: string, detail: string | undefined, turn: number): PlanMutation {
+    const lines = rawTitle
+      .split("\n")
+      .map((l) => l.replace(/^\s*(?:[-*]|\d+[.)])\s*/, "").trim())
+      .filter((l) => l.length > 0)
+      .slice(0, MAX_BULK_ADD);
+
+    if (lines.length === 0) {
+      return { ok: false, error: "No task title provided." };
+    }
+
+    const added: PlanTask[] = [];
+    let skippedDuplicate = 0;
+    for (const line of lines) {
+      if (line.length < MIN_TITLE_LEN) continue;
+      if (this.tasks.length >= MAX_PLAN_TASKS) {
+        return added.length > 0
+          ? {
+              ok: true,
+              tasks: added,
+              message:
+                `Added ${added.length} task(s); plan is now full ` +
+                `(${MAX_PLAN_TASKS} max). Complete or drop tasks before adding more.`,
+            }
+          : {
+              ok: false,
+              error: `Plan is full (${MAX_PLAN_TASKS} tasks). Complete or drop tasks before adding more.`,
+            };
+      }
+      const title = clamp(line, MAX_TITLE_LEN);
+      const key = dedupKey(title);
+      if (this.seen.has(key)) {
+        skippedDuplicate++;
+        continue;
+      }
+      this.seen.add(key);
+      const task: PlanTask = {
+        id: `task-${++this.counter}`,
+        uuid: randomUUID(),
+        title,
+        // A bulk add shares one detail across lines only when there is exactly
+        // one line; otherwise the detail would be misattributed to every task.
+        detail: lines.length === 1 && detail ? clamp(detail, MAX_DETAIL_LEN) : undefined,
+        status: "pending",
+        createdTurn: turn,
+        updatedTurn: turn,
+      };
+      this.tasks.push(task);
+      this.byId.set(task.id, task);
+      added.push(task);
+    }
+
+    if (added.length === 0) {
+      return {
+        ok: false,
+        error:
+          skippedDuplicate > 0
+            ? "Every task in that call already exists in the plan. Call plan action=list to see it."
+            : "No valid task titles in that call.",
+      };
+    }
+
+    this._revision += 1;
+    const dupNote = skippedDuplicate > 0 ? ` (${skippedDuplicate} duplicate(s) skipped)` : "";
+    return {
+      ok: true,
+      tasks: added,
+      message: `Added ${added.length} task(s)${dupNote}: ${added.map((t) => t.id).join(", ")}.`,
+    };
+  }
+
+  /**
+   * Mark a task `active`, demoting whatever was active before back to
+   * `pending`. The single-active invariant is what gives drift detection a
+   * point of reference rather than a cloud (see the module doc); enforcing it
+   * here rather than trusting the model is the whole reason this is a typed
+   * ledger instead of a text field.
+   */
+  start(id: string, turn: number): PlanMutation {
+    const task = this.byId.get(id);
+    if (!task) return { ok: false, error: this.unknownId(id) };
+    if (task.status === "done" || task.status === "dropped") {
+      return {
+        ok: false,
+        error: `${id} is already ${task.status}. Add a new task instead of restarting a closed one.`,
+      };
+    }
+    const touched: PlanTask[] = [];
+    const previous = this.activeTask();
+    if (previous && previous.id !== id) {
+      previous.status = "pending";
+      previous.updatedTurn = turn;
+      touched.push(previous);
+    }
+    task.status = "active";
+    task.updatedTurn = turn;
+    touched.push(task);
+    this._revision += 1;
+    const demoted = previous && previous.id !== id ? ` (${previous.id} back to pending)` : "";
+    return { ok: true, tasks: touched, message: `${id} is now active${demoted}.` };
+  }
+
+  /** Close a task as finished, optionally recording how. */
+  complete(id: string, detail: string | undefined, turn: number): PlanMutation {
+    return this.close(id, "done", detail, turn);
+  }
+
+  /**
+   * Close a task as deliberately abandoned. Distinct from `complete` because a
+   * dropped task is NOT progress — it stops anchoring drift either way, but
+   * conflating the two would let an agent "finish" a plan by discarding it.
+   */
+  drop(id: string, detail: string | undefined, turn: number): PlanMutation {
+    return this.close(id, "dropped", detail, turn);
+  }
+
+  private close(
+    id: string,
+    status: "done" | "dropped",
+    detail: string | undefined,
+    turn: number,
+  ): PlanMutation {
+    const task = this.byId.get(id);
+    if (!task) return { ok: false, error: this.unknownId(id) };
+    if (task.status === status) {
+      return { ok: false, error: `${id} is already ${status}.` };
+    }
+    task.status = status;
+    if (detail) task.detail = clamp(detail, MAX_DETAIL_LEN);
+    task.updatedTurn = turn;
+    this._revision += 1;
+    return { ok: true, tasks: [task], message: `${id} marked ${status}.` };
+  }
+
+  /** Attach or replace a task's note without changing its status. */
+  note(id: string, detail: string, turn: number): PlanMutation {
+    const task = this.byId.get(id);
+    if (!task) return { ok: false, error: this.unknownId(id) };
+    task.detail = clamp(detail, MAX_DETAIL_LEN);
+    task.updatedTurn = turn;
+    this._revision += 1;
+    return { ok: true, tasks: [task], message: `Noted on ${id}.` };
+  }
+
+  private unknownId(id: string): string {
+    const known = this.tasks.map((t) => t.id).join(", ");
+    return known
+      ? `No task with id '${id}'. Known ids: ${known}.`
+      : `No task with id '${id}'. The plan is empty — use action='add' first.`;
+  }
+
+  /**
+   * Free-text corpus of the open plan, used by drift detection to build its
+   * anchor term set. Only OPEN tasks contribute: a completed or dropped task
+   * must not keep anchoring the agent to work it has already left behind, or
+   * drift would become impossible to trip on a long run.
+   */
+  openText(): string {
+    return this.open()
+      .map((t) => `${t.title} ${t.detail ?? ""}`)
+      .join(" ")
+      .trim();
+  }
+
+  /**
+   * Compact plan block injected into the agent's context. Re-rendered from
+   * structured state every time, which is precisely what makes the plan survive
+   * `compactMessagesWithLLM` eating the message that previously carried it.
+   *
+   * Closed tasks are summarized as a count rather than listed line by line —
+   * on a 40-turn run the done pile is the majority of the ledger and the model
+   * needs to see what is LEFT, not a changelog. The active task is called out
+   * first because it is the single thing the agent is supposed to be doing.
+   */
+  render(opts: { limit?: number } = {}): string {
+    if (this.tasks.length === 0) return "";
+    const limit = opts.limit ?? DEFAULT_RENDER_LIMIT;
+    const open = this.open();
+    const doneCount = this.tasks.filter((t) => t.status === "done").length;
+    const droppedCount = this.tasks.filter((t) => t.status === "dropped").length;
+
+    const shown = open.slice(0, limit);
+    const omitted = open.length - shown.length;
+
+    const lines = shown.map((t) => {
+      const marker = t.status === "active" ? "▶" : "·";
+      const detail = t.detail ? ` — ${t.detail}` : "";
+      return `${marker} [${t.id}] ${t.title}${detail}`;
+    });
+
+    const header = [
+      "## Your plan (TODO ledger)",
+      "The authoritative list of what you decided to do on this target. `▶` marks the",
+      "task you are working RIGHT NOW. Keep it current with the `plan` tool: mark a task",
+      "`complete` the moment it is finished, `drop` it when you have ruled it out, and",
+      "`add` new tasks as you discover leads. If you are about to work on something that",
+      "is not on this list, add it and `start` it first — an out-of-date plan is worse",
+      "than no plan.",
+    ].join("\n");
+
+    const body = lines.length > 0 ? lines.join("\n") : "(no open tasks — add the next one before continuing)";
+    const omittedNote = omitted > 0 ? `\n…and ${omitted} more open (call plan action=list).` : "";
+    const closed =
+      doneCount > 0 || droppedCount > 0
+        ? `\nClosed so far: ${doneCount} done, ${droppedCount} dropped.`
+        : "";
+
+    return `${header}\n${body}${omittedNote}${closed}`;
+  }
+}
+
+/**
+ * Apply a validated `plan` action to a ledger. Kept as a free function rather
+ * than a ledger method so the tool handler is a pure dispatch with no branching
+ * of its own, and so the action semantics can be unit-tested without standing
+ * up a ToolExecutor.
+ */
+export function applyPlanAction(
+  ledger: TaskLedger,
+  args: PlanAction,
+  turn: number,
+): PlanMutation {
+  switch (args.action) {
+    case "add":
+      return ledger.add(args.title, args.detail, turn);
+    case "start":
+      return ledger.start(args.id, turn);
+    case "complete":
+      return ledger.complete(args.id, args.detail, turn);
+    case "drop":
+      return ledger.drop(args.id, args.detail, turn);
+    case "note":
+      return ledger.note(args.id, args.detail, turn);
+    case "list":
+      // A read, not a mutation — revision deliberately does NOT bump, so a
+      // model polling `list` can't force the plan block to re-inject every turn.
+      return {
+        ok: true,
+        tasks: [...ledger.all()],
+        message: `${ledger.size} task(s) in the plan; ${ledger.open().length} open.`,
+      };
+  }
+}

--- a/packages/core/src/agent/tools.test.ts
+++ b/packages/core/src/agent/tools.test.ts
@@ -13,6 +13,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { TaskLedger } from "./task-ledger.js";
 
 const ORIGINAL_JIT_SKILLS_ENV = process.env.PWNKIT_FEATURE_JIT_SKILLS;
 const ORIGINAL_LOOT_LEDGER_ENV = process.env.PWNKIT_FEATURE_LOOT_LEDGER;
@@ -275,6 +276,43 @@ describe("ToolExecutor", () => {
       targetInfo: {},
     };
     executor = new ToolExecutor(ctx, null);
+  });
+
+  it("routes plan mutations through the task ledger with the current turn", async () => {
+    const plan = new TaskLedger();
+    ctx.plan = plan;
+    ctx.currentTurn = 7;
+
+    const added = await executor.execute({
+      name: "plan",
+      arguments: { action: "add", title: "Map the authenticated API surface" },
+    });
+
+    expect(added.success).toBe(true);
+    expect(added.output).toMatchObject({
+      total: 1,
+      open: [{ id: "task-1", status: "pending" }],
+    });
+    expect(plan.get("task-1")).toMatchObject({ createdTurn: 7, updatedTurn: 7 });
+
+    const started = await executor.execute({
+      name: "plan",
+      arguments: { action: "start", id: "task-1" },
+    });
+    expect(started.success).toBe(true);
+    expect(plan.get("task-1")).toMatchObject({ status: "active", updatedTurn: 7 });
+  });
+
+  it("explains that plan tracking is unavailable when no ledger is configured", async () => {
+    const result = await executor.execute({
+      name: "plan",
+      arguments: { action: "list" },
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      output: { enabled: false },
+    });
   });
 
   // ── save_finding ──

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -17,6 +17,7 @@ import type {
 import { resolveIdentities, compareRoles } from "@pwnkit/shared";
 import type { ToolDefinition, ToolCall, ToolResult, ToolContext, AgentRole } from "./types.js";
 import type { LootKind } from "./loot.js";
+import { applyPlanAction, validatePlanArgs } from "./task-ledger.js";
 import type { OastHandle } from "../oast/types.js";
 import {
   confirmOast,
@@ -4467,6 +4468,64 @@ export class ToolExecutor {
   }
 
   /**
+   * `plan` — read and mutate the agent's typed TODO ledger.
+   *
+   * Two-stage, per the structured-output discipline in agent/AGENTS.md §1:
+   * `validatePlanArgs` parses the raw payload against a Zod discriminated
+   * union first and a malformed call is returned as an ERROR result naming the
+   * offending field, so the model self-corrects on the next turn rather than
+   * silently no-oping. Only after validation does `applyPlanAction` touch the
+   * ledger. Semantic rejections from the ledger itself (unknown id, restarting
+   * a closed task, plan full) come back the same way and for the same reason.
+   *
+   * When the feature is off there is no ledger, and this returns a graceful
+   * explanatory success rather than an error — same contract as `use_loot` and
+   * `oast_register`, so a model that calls a disabled tool is informed, not
+   * punished with a failed turn.
+   */
+  private planTool(args: Record<string, unknown>): ToolResult {
+    const ledger = this.ctx.plan;
+    if (!ledger) {
+      return {
+        success: true,
+        output: {
+          enabled: false,
+          message:
+            "Plan tracking is not enabled for this scan. Continue without it — keep your objective in your own reasoning.",
+        },
+      };
+    }
+
+    const validated = validatePlanArgs(args);
+    if (!validated.ok) {
+      return { success: false, output: null, error: validated.error };
+    }
+
+    const turn = this.ctx.currentTurn ?? 0;
+    const result = applyPlanAction(ledger, validated.args, turn);
+    if (!result.ok) {
+      return { success: false, output: null, error: result.error };
+    }
+
+    return {
+      success: true,
+      output: {
+        message: result.message,
+        // Always return the full open plan, not just the mutated tasks: the
+        // model's next decision depends on what is LEFT, and echoing only the
+        // task it just touched invites it to lose track of the rest.
+        open: ledger.open().map((t) => ({
+          id: t.id,
+          title: t.title,
+          detail: t.detail,
+          status: t.status,
+        })),
+        total: ledger.size,
+      },
+    };
+  }
+
+  /**
    * `oast_register` (pwnkit#659) — mint a unique out-of-band interaction handle
    * from the hosted collaborator. Returns a unique subdomain + correlation
    * token + ready-to-inject payload URLs. When no collaborator is configured
@@ -5688,6 +5747,8 @@ export function getToolsForRole(role: string, opts?: { hasScope?: boolean; webMo
   const skillTools = featureFlags.jitSkills ? ["list_skills", "load_skill"] : [];
   // pwnkit#567 — loot retrieval tool, only when the ledger feature is on.
   const lootTools = featureFlags.lootLedger ? ["use_loot"] : [];
+  // Typed TODO ledger — the `plan` tool, only when the feature is on.
+  const planTools = featureFlags.agentPlan ? ["plan"] : [];
   // pwnkit#555: scanner wrappers only when the engagement explicitly permits
   // generic-scanner traffic. Default-off preserves pwnkit#217 stealth.
   const scannerTools = opts?.allowScanners ? [...SCANNER_TOOL_NAMES] : [];
@@ -5717,6 +5778,7 @@ export function getToolsForRole(role: string, opts?: { hasScope?: boolean; webMo
     ...mongoTools,
     ...skillTools,
     ...lootTools,
+    ...planTools,
     ...scannerTools,
     ...cloudTools,
     ...orchestratorTools,
@@ -5733,6 +5795,9 @@ export function getToolsForRole(role: string, opts?: { hasScope?: boolean; webMo
     // Keep use_loot out of the audit/review "everything" set when the loot
     // ledger feature is off (parity with the JIT-skill gating above).
     && (featureFlags.lootLedger || name !== "use_loot")
+    // The `plan` tool follows the same gating: out of the audit/review
+    // "everything" set when the plan ledger feature is off.
+    && (featureFlags.agentPlan || name !== "plan")
     // Scanner wrappers stay out of the audit/review "everything" set too,
     // unless the engagement opted in. Without this they'd leak into
     // allEnabledTools regardless of allowScanners (regression of pwnkit#217).

--- a/packages/core/src/agent/tools/dispatch.test.ts
+++ b/packages/core/src/agent/tools/dispatch.test.ts
@@ -19,6 +19,7 @@ const EXPECTED_ROUTING: Record<string, string> = {
   save_finding: "saveFinding",
   query_findings: "queryFindings",
   use_loot: "useLoot",
+  plan: "planTool",
   update_finding: "updateFinding",
   read_file: "readFile",
   apply_patch: "applyPatch",

--- a/packages/core/src/agent/tools/findings.ts
+++ b/packages/core/src/agent/tools/findings.ts
@@ -223,6 +223,41 @@ export const findingsToolDefinitions: Record<string, ToolDefinition> = {
     },
   },
 
+  // Typed TODO / plan ledger. One tool with an `action` discriminator rather
+  // than five separate tools — five schemas in every request for one concept
+  // is a bad trade, and a small closed enum is something models get right.
+  // Arguments are Zod-validated (`validatePlanArgs`) and a rejection comes back
+  // as an is_error result so the model self-corrects, per agent/AGENTS.md §1.
+  plan: {
+    name: "plan",
+    description:
+      "Maintain your TODO list for this target. Your plan is re-shown to you every turn, so it is the one piece of state guaranteed to survive context compaction — keep it current and it will keep you on track across a long run. Use action='add' to record a task you intend to do (pass several at once by putting one task per line in `title`), action='start' to mark the task you are working on RIGHT NOW (only one task can be active; starting another sends the previous one back to pending), action='complete' when it is genuinely finished, action='drop' when you have ruled it out, action='note' to record what you learned on a task without closing it, and action='list' to see everything. Add and start a task BEFORE you begin work that is not already on the plan.",
+    parameters: {
+      action: {
+        type: "string",
+        description:
+          "What to do: add a task, start (make active) an existing task, complete it, drop it, note progress on it, or list the plan.",
+        enum: ["add", "start", "complete", "drop", "note", "list"],
+      },
+      title: {
+        type: "string",
+        description:
+          "Required for action='add'. One-line statement of the task. To seed several tasks in a single call, put one task per line.",
+      },
+      id: {
+        type: "string",
+        description:
+          "Required for action='start'|'complete'|'drop'|'note'. The task id, e.g. 'task-2'.",
+      },
+      detail: {
+        type: "string",
+        description:
+          "Optional for add/complete/drop; required for action='note'. The concrete approach, endpoint, payload, or what you learned.",
+      },
+    },
+    required: ["action"],
+  },
+
   update_finding: {
     name: "update_finding",
     description:
@@ -257,6 +292,7 @@ export const findingsDispatch: Record<string, string> = {
   save_finding: "saveFinding",
   query_findings: "queryFindings",
   use_loot: "useLoot",
+  plan: "planTool",
   update_finding: "updateFinding",
   done: "markDone",
 };

--- a/packages/core/src/agent/tools/index.ts
+++ b/packages/core/src/agent/tools/index.ts
@@ -59,6 +59,7 @@ const TOOL_REGISTRY_ORDER = [
   "save_finding",
   "query_findings",
   "use_loot",
+  "plan",
   "update_finding",
   "read_file",
   "apply_patch",

--- a/packages/core/src/agent/tools/system.ts
+++ b/packages/core/src/agent/tools/system.ts
@@ -71,6 +71,32 @@ export const systemToolDefinitions: Record<string, ToolDefinition> = {
     required: ["command"],
   },
 
+  plan: {
+    name: "plan",
+    description:
+      "Maintain the scan's compact task ledger. Add concrete next steps, mark the one currently being worked, then complete or drop it. Use list to review open work before changing approach.",
+    parameters: {
+      action: {
+        type: "string",
+        description: "Plan action",
+        enum: ["add", "start", "complete", "drop", "note", "list"],
+      },
+      title: {
+        type: "string",
+        description: "Task title for action add. A newline-separated list adds several tasks.",
+      },
+      id: {
+        type: "string",
+        description: "Task id for start, complete, drop, or note (for example task-2).",
+      },
+      detail: {
+        type: "string",
+        description: "Optional concrete note for add, complete, or drop; required for note.",
+      },
+    },
+    required: ["action"],
+  },
+
   spawn_agent: {
     name: "spawn_agent",
     description:
@@ -111,4 +137,5 @@ export const systemDispatch: Record<string, string> = {
   bash: "shellExec",
   spawn_agent: "spawnAgent",
   pty_session: "ptySession",
+  plan: "planTool",
 };

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -5,6 +5,7 @@ import type { AttributionConfig } from "../scope/attribution.js";
 import type { EngagementPosture } from "../scope/engagement-profile.js";
 import type { EnforcementTracker } from "../scope/enforcement.js";
 import type { LootLedger } from "./loot.js";
+import type { TaskLedger } from "./task-ledger.js";
 import type { OastCollaborator } from "../oast/types.js";
 import type { SessionEngine } from "./session.js";
 import type { WafDetector } from "../scope/waf-detect.js";
@@ -257,6 +258,24 @@ export interface ToolContext {
    * undefined otherwise so the default scan path is unchanged.
    */
   loot?: LootLedger;
+  /**
+   * Typed TODO / plan ledger. When set, the `plan` tool reads and mutates it,
+   * and the agent loop re-injects a compact plan block re-rendered from this
+   * structured state each turn (so the plan survives context compaction). The
+   * ledger's open tasks are also the anchor set for task-drift detection
+   * (`agent/drift.ts`). Created only when `features.agentPlan` is on;
+   * undefined otherwise, in which case `plan` returns a graceful
+   * "not enabled" result rather than an error.
+   */
+  plan?: TaskLedger;
+  /**
+   * The agent turn currently executing. Kept fresh by the loop so tools can
+   * stamp turn numbers on state they create (the plan ledger records the turn
+   * a task was added and last touched, which is what makes a stale task
+   * visible). Undefined outside the native loop, in which case turn stamps
+   * fall back to 0.
+   */
+  currentTurn?: number;
   /**
    * Hosted OAST interaction collaborator (pwnkit#659). When set, the
    * `oast_register` / `oast_poll` tools mint unique interaction handles and


### PR DESCRIPTION
## Scope
Adds the optional, typed agent TODO ledger and deterministic task-drift signal. `PWNKIT_FEATURE_AGENT_PLAN` and `PWNKIT_FEATURE_DRIFT_DETECTION` both remain default-off.

- exposes a validated `plan` tool and re-injects its compact state after context compaction
- detects repeated tool activity that no longer matches the open plan
- restores dynamic playbook guidance after compaction
- documents the flags and exercises dispatcher, feature-boundary, ledger, drift, and real compaction behavior

## Verification
- `pnpm build`
- `pnpm lint`
- `pnpm test:public` — 6,348 passed, 14 skipped
- `foxguard diff origin/main --format json --severity high` — 0 new findings

The full-repository secret scan reports only pre-existing test fixtures; none are in this PR’s 19 changed files.