### PR TITLE
fix(triage): reject preexisting build-control claims

### DIFF
--- a/packages/core/src/triage/holding-it-wrong.test.ts
+++ b/packages/core/src/triage/holding-it-wrong.test.ts
@@ -214,13 +214,13 @@ describe("isHoldingItWrong — verified-by-design npm duds (#802 regression)", (
     expect(isHoldingItWrong(f).isHoldingItWrong).toBe(true);
   });
 
-  // ── The two that are GENUINELY real — must survive the gate ──
+  // ── The one that is genuinely real must survive; build-control candidates do not ──
 
-  it("dd-trace-js: unescaped git URL interpolated into a JS banner is REAL (not suppressed)", () => {
+  it("dd-trace-js: banner interpolation requires pre-existing build control", () => {
     const f = makeFinding({
       title: "Code injection in dd-trace-js esbuild banner",
       description:
-        "datadog-esbuild interpolates an unescaped git remote.origin.url into a single-quoted JS banner string; a malicious repository URL injects arbitrary JS into every shipped bundle.",
+        "datadog-esbuild interpolates an unescaped git remote.origin.url into a single-quoted JS banner string. A quote can alter generated JavaScript, but an attacker must control the local Git configuration, source repository, or build environment before the build; a source repository's .git/config does not propagate to a clone.",
       category: "code-injection" as AttackCategory,
       evidence: {
         request:
@@ -229,9 +229,10 @@ describe("isHoldingItWrong — verified-by-design npm duds (#802 regression)", (
       },
     });
     const r = isHoldingItWrong(f);
-    expect(r.isHoldingItWrong).toBe(false);
-    expect(r.reason).toBeNull();
+    expect(r.isHoldingItWrong).toBe(true);
+    expect(r.reason).toMatch(/no independent trust boundary/i);
   });
+
 
   it("justeattakeaway: attacker filename interpolated into execSync is REAL (not suppressed)", () => {
     const f = makeFinding({

--- a/packages/core/src/triage/holding-it-wrong.ts
+++ b/packages/core/src/triage/holding-it-wrong.ts
@@ -176,6 +176,17 @@ const TEMPLATE_SSTI_OR_SANDBOX_PATTERNS: RegExp[] = [
   /already\s+(?:running|executing)\s+(?:inside|within)\s+the\s+sandbox/i,
 ];
 
+/**
+ * A source-level sink is not independently exploitable when the proposed
+ * attacker already controls the repository, local Git configuration, or build
+ * environment that supplies the value. This check must run before the generic
+ * interpolation override below.
+ */
+const PREEXISTING_BUILD_CONTROL_PATTERNS: RegExp[] = [
+  /\b(?:attacker|malicious)\b[^.]{0,120}\b(?:controls?|modif(?:y|ies)|writes?)\b[^.]{0,120}\b(?:local\s+git\s+(?:config(?:uration)?|metadata)|build\s+(?:environment|configuration)|source\s+repository)\b/i,
+  /\b(?:local\s+git\s+(?:config(?:uration)?|metadata)|remote\.origin\.url)\b[^.]{0,120}\b(?:requires?|only\s+(?:if|when)|presupposes)\b[^.]{0,120}\b(?:attacker|malicious)\b[^.]{0,80}\b(?:control|write|modif)/i,
+];
+
 // ────────────────────────────────────────────────────────────────────
 // Public API
 // ────────────────────────────────────────────────────────────────────
@@ -201,6 +212,16 @@ export function isHoldingItWrong(finding: Finding): HoldingItWrongResult {
   const response = finding.evidence?.response ?? "";
   const allText = `${title}\n${description}\n${analysis}`;
   const codeText = `${allText}\n${request}\n${response}`;
+
+
+  // 0. A quote-breaking source-level sink is not a vulnerability if the
+  //    supposed attacker already owns the build input that supplies it.
+  if (PREEXISTING_BUILD_CONTROL_PATTERNS.some((p) => p.test(allText))) {
+    return {
+      isHoldingItWrong: true,
+      reason: "The proposed attacker already controls the repository, local Git configuration, or build environment that supplies the value; no independent trust boundary is crossed.",
+    };
+  }
 
   // 0. Real-injection override (#802). If untrusted DATA is interpolated /
   //    concatenated into a sink by the library's own code path — and the


### PR DESCRIPTION
## Scope
Suppresses a false-positive class where the claimed attacker must already control the local Git configuration, source repository, or build environment that supplies the value. That condition creates no independent trust boundary.

The regression case covers `remote.origin.url` interpolation in a generated build banner. Actual independent attacker-controlled filename/argument injection remains accepted.

## Verification
- `pnpm build`
- `pnpm lint`
- `pnpm test:public` — 6,348 passed, 14 skipped
- `foxguard diff origin/main --format json --severity high` — 0 new findings

The repository-wide secret scan reports only pre-existing fixture detections; none are in this PR’s two changed files.