### PR TITLE
docs: clarify public install, scopes, and model routing

### DIFF
--- a/docs/src/content/docs/api-keys.md
+++ b/docs/src/content/docs/api-keys.md
@@ -1,6 +1,6 @@
 ---
 title: API Keys
-description: Supported LLM providers, environment variables, and priority order.
+description: Supported LLM providers, environment variables, and model routing.
 ---
 
 pwnkit's `api` runtime (the default) makes direct HTTP calls to an LLM provider. You need to set provider credentials as environment variables.
@@ -9,39 +9,49 @@ pwnkit's `api` runtime (the default) makes direct HTTP calls to an LLM provider.
 
 | Provider | Environment Variable | Notes |
 |----------|---------------------|-------|
+| **Z.ai GLM** | `Z_AI_API_KEY` | `glm-5.3` is the default for the Z.ai route. Uses Z.ai's Anthropic-compatible Messages API. |
+| **Alibaba Qwen** | `QWEN_API_KEY` | Use `--model qwen3.8-max` or `PWNKIT_MODEL=qwen3.8-max`. Uses Alibaba Model Studio's OpenAI-compatible endpoint. |
+| **Moonshot Kimi** | `KIMI_API_KEY` | Use `--model k3`. Uses Moonshot's Anthropic-compatible Coding endpoint. |
 | **ChatGPT Codex** | `PWNKIT_CHATGPT_OAUTH_REFRESH_TOKEN` | Uses ChatGPT/Codex subscription auth from `codex login`. Copy the refresh token from `~/.codex/auth.json`. |
-| **OpenRouter** | `OPENROUTER_API_KEY` | Recommended. One key, access to many models (Claude, GPT-4, Llama, Mistral, and more). Includes free-tier models. Get a key at [openrouter.ai](https://openrouter.ai). |
-| **Anthropic** | `ANTHROPIC_API_KEY` | Direct access to Claude models. Get a key at [console.anthropic.com](https://console.anthropic.com). |
+| **DeepSeek** | `DEEPSEEK_API_KEY` | Direct DeepSeek API access. |
+| **OpenRouter** | `OPENROUTER_API_KEY` | Access to many hosted model families through one API. |
+| **Anthropic** | `ANTHROPIC_API_KEY` | Direct access to Claude models. |
 | **Azure OpenAI** | `AZURE_OPENAI_API_KEY` | Azure-hosted OpenAI models. See [Azure configuration](#azure-openai-configuration) below for additional settings. |
-| **OpenAI** | `OPENAI_API_KEY` | Direct access to GPT models. Get a key at [platform.openai.com](https://platform.openai.com). |
+| **OpenAI** | `OPENAI_API_KEY` | Direct access to GPT models. |
 
-## Priority order
+## Model routing
 
-When multiple provider credentials are set, pwnkit uses this priority:
+Set `--model <id>` or `PWNKIT_MODEL=<id>` when more than one provider
+credential is present. pwnkit routes recognized model families to the provider
+whose credentials are configured:
 
-1. `PWNKIT_CHATGPT_OAUTH_REFRESH_TOKEN` (ChatGPT Codex subscription auth)
-2. `OPENROUTER_API_KEY`
-3. `ANTHROPIC_API_KEY`
-4. `AZURE_OPENAI_API_KEY`
-5. `OPENAI_API_KEY` (lowest priority)
+- `glm-*` / `z-ai/*` → Z.ai
+- `qwen*` → Alibaba Qwen
+- `k3` / `kimi*` → Moonshot Kimi
+- `claude*` / `anthropic/*` → Anthropic, then OpenRouter when direct Anthropic
+  credentials are absent
+- `gpt-*` / `o*` → ChatGPT Codex subscription when configured, otherwise
+  OpenAI
 
-Only one provider credential is needed. If you set multiple, the highest-priority one is used.
+Without an explicit model, pwnkit selects an available provider fallback. Pin a
+model rather than relying on ambient credential order.
 
 ## Setting your key
 
 ### macOS / Linux
-
 ```bash
-# Add to your shell profile (~/.zshrc, ~/.bashrc, etc.)
+# Set the provider key.
+export Z_AI_API_KEY="..."
+export QWEN_API_KEY="..."
+
+# Select its matching model at run time.
+pwnkit scan --target https://api.example.com --scope ./scope.json --model glm-5.3
+pwnkit scan --target https://api.example.com --scope ./scope.json --model qwen3.8-max
+
+# Or use OpenRouter.
 export OPENROUTER_API_KEY="sk-or-v1-..."
-```
 
-Then reload your shell or run `source ~/.zshrc`.
-
-For ChatGPT Codex subscription auth, run `codex login`, then copy
-`tokens.refresh_token` from `~/.codex/auth.json`:
-
-```bash
+# ChatGPT Codex subscription auth.
 export PWNKIT_CHATGPT_OAUTH_REFRESH_TOKEN="..."
 ```
 
@@ -58,14 +68,11 @@ Add the key as a repository secret, then reference it in your workflow:
     OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
 ```
 
-### Why OpenRouter is recommended
+## When to use OpenRouter
 
-OpenRouter acts as a unified gateway to many LLM providers. Benefits:
-
-- **One key, many models** — access Claude, GPT-4, Llama, Mistral, and others
-- **Free-tier models available** — useful for testing and CI
-- **Automatic fallback** — if one provider is down, OpenRouter can route to another
-- **Usage dashboard** — track costs across all models in one place
+OpenRouter is useful when you want to select a model family that is not
+available through a direct provider credential. It is not required for Z.ai
+GLM, Alibaba Qwen, Moonshot Kimi, Anthropic, OpenAI, Azure, or DeepSeek.
 
 ## Azure OpenAI configuration
 
@@ -97,9 +104,8 @@ If you rely on Codex config instead of env vars, make sure `~/.codex/config.toml
 If you prefer not to use API keys at all, you can use CLI runtimes for supported workflows. Claude can run live target scans through its native subscription loop. Codex and Gemini are source-review oriented CLI runtimes:
 
 ```bash
-# Use Claude Code CLI (requires Claude subscription)
-pwnkit scan --target https://api.example.com/chat --runtime claude
-
+# Use Claude Code CLI for an authorized live target
+pwnkit scan --target https://api.example.com/chat --scope ./scope.json --runtime claude
 # Use Codex CLI for source review
 pwnkit review ./my-repo --runtime codex
 

--- a/docs/src/content/docs/commands.md
+++ b/docs/src/content/docs/commands.md
@@ -9,38 +9,42 @@ All commands are available via `pwnkit <command>`. You can also skip the subcomm
 
 Probe AI/LLM apps, web apps, APIs, or MCP servers for vulnerabilities.
 
+Live network targets require `--scope <file>`. The CLI refuses an unscoped live
+target before making a request. Local source review and package audit commands
+do not need a network-target scope.
+
 ```bash
 # Scan an LLM API
-pwnkit scan --target https://api.example.com/chat
+pwnkit scan --target https://api.example.com/chat --scope ./scope.json
 
 # Scan a traditional web app
-pwnkit scan --target https://example.com --mode web
+pwnkit scan --target https://example.com --mode web --scope ./scope.json
 
 # Deep scan with Claude Code CLI
-pwnkit scan --target https://api.example.com/chat --depth deep --runtime claude
+pwnkit scan --target https://api.example.com/chat --scope ./scope.json --depth deep --runtime claude
 
 # Authenticated scan using a bearer token
-pwnkit scan --target https://api.example.com \
+pwnkit scan --target https://api.example.com --scope ./scope.json \
   --auth '{"type":"bearer","token":"eyJhbGciOi..."}'
 
 # Scan an API with an OpenAPI spec pre-loaded
-pwnkit scan --target https://api.example.com --api-spec ./openapi.yaml
+pwnkit scan --target https://api.example.com --scope ./scope.json --api-spec ./openapi.yaml
 
 # Run 5 attack strategies in parallel — first to succeed wins
-pwnkit scan --target https://example.com --mode web --race
+pwnkit scan --target https://example.com --mode web --scope ./scope.json --race
 
 # Evidence-Gated Attack Tree Search (EGATS)
-pwnkit scan --target https://example.com --mode web --egats
+pwnkit scan --target https://example.com --mode web --scope ./scope.json --egats
 
 # Abort cleanly if the scan exceeds a USD ceiling
-pwnkit scan --target https://example.com --mode web --cost-ceiling 5
+pwnkit scan --target https://example.com --mode web --scope ./scope.json --cost-ceiling 5
 
 # Export findings to GitHub Issues
-pwnkit scan --target https://example.com --mode web \
+pwnkit scan --target https://example.com --mode web --scope ./scope.json \
   --export github:myorg/myrepo
 
 # Generate an HTML report (auto-opens in browser)
-pwnkit scan --target https://example.com --mode web \
+pwnkit scan --target https://example.com --mode web --scope ./scope.json \
   --format html
 ```
 
@@ -49,7 +53,7 @@ pwnkit scan --target https://example.com --mode web \
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--target <url>` | The URL or `mcp://` endpoint to scan | (required) |
-| `--mode <mode>` | Scan mode: `probe`, `deep`, `mcp`, `web` | auto |
+| `--scope <file>` | JSON engagement scope for a live network target | (required for live targets) |
 | `--depth <depth>` | Scan depth: `quick`, `default`, `deep` | `default` |
 | `--runtime <rt>` | Runtime: `auto`, `api`, `claude`, `codex`, `gemini` | `auto` |
 | `--format <fmt>` | Output format: `terminal`, `json`, `md`, `html`, `sarif`, `pdf` | `terminal` |
@@ -93,7 +97,7 @@ The `--auth` flag accepts either an inline JSON string or a path to a JSON file.
 Point `--api-spec` at an OpenAPI 3.x or Swagger 2.0 document (JSON or YAML). pwnkit will parse the spec, extract all endpoints with their parameter schemas and auth requirements, and seed the recon phase with that knowledge so the agent starts pentesting with full endpoint awareness instead of having to crawl.
 
 ```bash
-pwnkit scan --target https://api.example.com --api-spec ./openapi.yaml
+pwnkit scan --target https://api.example.com --scope ./scope.json --api-spec ./openapi.yaml
 ```
 
 ### `--race` — best-of-N strategy racing
@@ -109,7 +113,7 @@ EGATS performs a beam search over a tree of attack hypotheses, pruning branches 
 Set a hard per-scan USD ceiling:
 
 ```bash
-pwnkit scan --target https://example.com --mode web --cost-ceiling 5
+pwnkit scan --target https://example.com --mode web --scope ./scope.json --cost-ceiling 5
 ```
 
 If cumulative estimated spend exceeds the ceiling, pwnkit:

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -7,15 +7,26 @@ pwnkit is a general-purpose autonomous pentesting framework. It scans AI/LLM app
 
 ## Installation
 
-pwnkit is closed-source software. Public binary releases and the npm package have been retired.
+pwnkit is open-source software for authorized security research. Build it from
+source or run the public GHCR image. npm and standalone-binary releases are not
+published yet.
+
+### Source
 
 ```bash
-# Docker (recommended)
-docker run --rm -e OPENROUTER_API_KEY=$KEY \
-  ghcr.io/0sec-labs/pwnkit:latest scan --target https://example.com
+git clone https://github.com/0sec-labs/pwnkit.git
+cd pwnkit
+corepack enable
+pnpm install --frozen-lockfile
+pnpm build
+node dist/pwnkit.js --help
 ```
 
-For direct access, contact **security@0sec.ai**.
+### Docker
+
+```bash
+docker run --rm ghcr.io/0sec-labs/pwnkit:latest --help
+```
 
 ## Set up an API key
 
@@ -39,10 +50,30 @@ See [API Keys](/api-keys/) for full details on supported providers.
 
 ## Your first scan
 
+Every live network target needs an engagement scope. The CLI refuses an
+unscoped live target before making a request.
+
+```bash
+cat > scope.json <<'EOF'
+{"in_scope":["your-app.com"]}
+EOF
+```
+
+The connected examples below assume `./scope.json` allows their target. With
+Docker, mount the file and pass its container path to `--scope`.
+
+```bash
+docker run --rm \
+  -v "$PWD/scope.json:/work/scope.json:ro" \
+  -e OPENROUTER_API_KEY \
+  ghcr.io/0sec-labs/pwnkit:latest scan \
+  --target https://your-app.com --scope /work/scope.json
+```
+
 ### Scan an LLM API
 
 ```bash
-pwnkit scan --target https://your-app.com/api/chat
+pwnkit scan --target https://your-app.com/api/chat --scope ./scope.json
 ```
 
 This discovers the attack surface, launches targeted attacks (prompt injection, jailbreaks, data exfiltration), verifies every finding, and generates a report — typically in under 5 minutes.
@@ -50,7 +81,7 @@ This discovers the attack surface, launches targeted attacks (prompt injection, 
 ### Scan a web application
 
 ```bash
-pwnkit scan --target https://your-app.com --mode web
+pwnkit scan --target https://your-app.com --mode web --scope ./scope.json
 ```
 
 Runs autonomous pentesting against a web application using a shell-first approach. The agent gets `bash` as its primary tool and uses curl, python3, bash pipelines, and standard pentesting utilities to probe for CORS misconfigurations, exposed files, SSRF, XSS, SQL injection, SSTI, and other traditional web vulnerabilities. See [Architecture](/architecture/) for why shell-first beats structured tools.
@@ -81,11 +112,11 @@ pwnkit review https://github.com/user/repo
 You can skip the subcommand entirely. pwnkit figures out what to do:
 
 ```bash
-pwnkit-cli express              # audits npm package
-pwnkit-cli ./my-repo            # reviews source code
-pwnkit-cli https://github.com/user/repo  # clones and reviews
-pwnkit-cli https://example.com/api/chat  # scans LLM API
-pwnkit-cli https://example.com --mode web  # pentests web app
+pwnkit-cli express                         # audits npm package
+pwnkit-cli ./my-repo                       # reviews source code
+pwnkit-cli https://github.com/user/repo    # clones and reviews
+pwnkit scan --target https://your-app.com/api/chat --scope ./scope.json
+pwnkit scan --target https://your-app.com --mode web --scope ./scope.json
 ```
 
 ## Scan depth
@@ -100,10 +131,10 @@ Control how thorough the scan is:
 
 ```bash
 # Quick scan for CI
-pwnkit scan --target https://api.example.com/chat --depth quick
+pwnkit scan --target https://api.example.com/chat --scope ./scope.json --depth quick
 
 # Deep audit before launch
-pwnkit scan --target https://api.example.com/chat --depth deep
+pwnkit scan --target https://api.example.com/chat --scope ./scope.json --depth deep
 ```
 
 ## Common scenarios
@@ -115,6 +146,7 @@ Point pwnkit at an OpenAPI 3.x or Swagger 2.0 document and it will pre-load ever
 ```bash
 pwnkit scan \
   --target https://api.example.com \
+  --scope ./scope.json \
   --api-spec ./openapi.yaml \
   --mode web
 ```
@@ -125,19 +157,19 @@ Use `--auth` to pass credentials. Four types are supported: `bearer`, `cookie`, 
 
 ```bash
 # Bearer token (OAuth / JWT)
-pwnkit scan --target https://app.example.com \
+pwnkit scan --target https://app.example.com --scope ./scope.json \
   --auth '{"type":"bearer","token":"eyJhbGciOi..."}'
 
 # Session cookie
-pwnkit scan --target https://app.example.com \
+pwnkit scan --target https://app.example.com --scope ./scope.json \
   --auth '{"type":"cookie","value":"session=abc123"}'
 
 # Custom header (API key)
-pwnkit scan --target https://api.example.com \
+pwnkit scan --target https://api.example.com --scope ./scope.json \
   --auth '{"type":"header","name":"X-API-Key","value":"sk_live_..."}'
 
 # Or load from a file to avoid leaking to shell history
-pwnkit scan --target https://app.example.com --auth ./auth.json
+pwnkit scan --target https://app.example.com --scope ./scope.json --auth ./auth.json
 ```
 
 ### Multi-model ensemble via OpenRouter
@@ -148,11 +180,11 @@ Set `OPENROUTER_API_KEY` and pass `--model` to mix models across runs. OpenRoute
 export OPENROUTER_API_KEY="sk-or-..."
 
 # Use Claude Sonnet for hard targets
-pwnkit scan --target https://example.com --mode web \
+pwnkit scan --target https://example.com --mode web --scope ./scope.json \
   --model anthropic/claude-sonnet-4-5
 
 # Cheap and fast for CI
-pwnkit scan --target https://example.com --mode web \
+pwnkit scan --target https://example.com --mode web --scope ./scope.json \
   --model deepseek/deepseek-chat --depth quick
 ```
 
@@ -161,7 +193,7 @@ pwnkit scan --target https://example.com --mode web \
 Spawn 5 attack agents in parallel and let the fastest one win. Great for hard targets where a linear attack plan gets stuck.
 
 ```bash
-pwnkit scan --target https://example.com --mode web --race
+pwnkit scan --target https://example.com --mode web --scope ./scope.json --race
 ```
 
 ### Kali Docker executor
@@ -170,7 +202,7 @@ Enable `PWNKIT_FEATURE_DOCKER_EXECUTOR=1` to run every bash command inside a con
 
 ```bash
 export PWNKIT_FEATURE_DOCKER_EXECUTOR=1
-pwnkit scan --target https://example.com --mode web --verbose
+pwnkit scan --target https://example.com --mode web --scope ./scope.json --verbose
 ```
 
 Advanced overrides:
@@ -197,7 +229,7 @@ Push every confirmed finding to a GitHub repo as a labelled issue with evidence 
 
 ```bash
 export GITHUB_TOKEN="ghp_..."
-pwnkit scan --target https://example.com --mode web \
+pwnkit scan --target https://example.com --mode web --scope ./scope.json \
   --export github:myorg/myrepo
 ```
 
@@ -205,17 +237,17 @@ pwnkit scan --target https://example.com --mode web \
 
 ```bash
 # HTML (auto-opens in browser)
-pwnkit scan --target https://example.com --mode web \
+pwnkit scan --target https://example.com --mode web --scope ./scope.json \
   --depth deep \
   --format html
 
 # Markdown (printed to stdout; pipe to a file)
-pwnkit scan --target https://example.com --mode web \
+pwnkit scan --target https://example.com --mode web --scope ./scope.json \
   --depth deep \
   --format md > example-pentest.md
 
 # PDF (auto-opens in your default viewer and saves to a temp file)
-pwnkit scan --target https://example.com --mode web \
+pwnkit scan --target https://example.com --mode web --scope ./scope.json \
   --depth deep \
   --format pdf
 ```

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -33,18 +33,38 @@ docker run --rm ghcr.io/0sec-labs/pwnkit:latest --help
 pwnkit needs an LLM provider to power its agentic pipeline. Set one of these environment variables:
 
 ```bash
+# Set a matching provider key, then select its model with --model.
+
+# Z.ai GLM
+export Z_AI_API_KEY="..."
+
+# Alibaba Qwen
+export QWEN_API_KEY="..."
+
 # ChatGPT/Codex subscription auth
 export PWNKIT_CHATGPT_OAUTH_REFRESH_TOKEN="..."
 
-# Recommended — one key, many models
-export OPENROUTER_API_KEY="sk-or-..."
-
-# Or use a direct provider
+# Direct providers or OpenRouter
 export ANTHROPIC_API_KEY="sk-ant-..."
 export OPENAI_API_KEY="sk-..."
+export OPENROUTER_API_KEY="sk-or-..."
 ```
 
-pwnkit checks for credentials in this order: **ChatGPT Codex > OpenRouter > Anthropic > Azure OpenAI > OpenAI**. For ChatGPT Codex, run `codex login` and copy the refresh token from `~/.codex/auth.json` into `PWNKIT_CHATGPT_OAUTH_REFRESH_TOKEN`. For Azure, pwnkit needs both a base URL and a deployment/model name in addition to the key. You can set `AZURE_OPENAI_BASE_URL`, `AZURE_OPENAI_MODEL`, and `AZURE_OPENAI_WIRE_API` explicitly, or let pwnkit reuse a valid Azure-backed `~/.codex/config.toml`. For the Responses API, the Azure base URL should include `/openai/v1`. If the selected API runtime is incomplete, pwnkit now stops with a configuration error instead of running a broken scan. If no provider credentials are set, the `api` runtime will not work, but you can still use source-review CLI runtimes such as `--runtime codex` or live scanning through `--runtime claude` if those CLIs are installed and authenticated.
+pwnkit routes an explicit `--model` or `PWNKIT_MODEL` to its matching configured
+provider. `glm-5.3` uses Z.ai. `qwen3.8-max` uses Alibaba Model Studio. Pin a
+model whenever multiple provider credentials are present.
+
+For ChatGPT Codex, run `codex login` and copy the refresh token from
+`~/.codex/auth.json` into `PWNKIT_CHATGPT_OAUTH_REFRESH_TOKEN`. For Azure,
+pwnkit needs both a base URL and a deployment/model name in addition to the
+key. You can set `AZURE_OPENAI_BASE_URL`, `AZURE_OPENAI_MODEL`, and
+`AZURE_OPENAI_WIRE_API` explicitly, or let pwnkit reuse a valid Azure-backed
+`~/.codex/config.toml`. For the Responses API, the Azure base URL should include
+`/openai/v1`. If the selected API runtime is incomplete, pwnkit stops with a
+configuration error instead of running a broken scan. If no provider credentials
+are set, the `api` runtime will not work, but you can still use source-review
+CLI runtimes such as `--runtime codex` or live scanning through `--runtime
+claude` if those CLIs are installed and authenticated.
 
 See [API Keys](/api-keys/) for full details on supported providers.
 


### PR DESCRIPTION
## Scope
- replace stale closed-access installation copy with public source and GHCR guidance
- make live-target scope requirements explicit in getting-started and command examples
- document GLM-5.3, Qwen3.8-Max, Kimi, and model-aware provider routing

## Verification
- pnpm --filter @pwnkit/docs build
- rendered local preview checks for /getting-started/, /commands/, and /api-keys/

No runtime behavior changes.