### PR TITLE
docs(install): remove unclaimed npm install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,6 @@ test. It is not a substitute for a written testing scope.
 
 ## Install
 
-### npm
-
-After the first npm release:
-
-```bash
-npx pwnkit@latest --help
-# or
-npm install --global pwnkit
-pwnkit --help
-```
-
 ### Source
 
 ```bash
@@ -93,12 +82,13 @@ environment and read each command's help before a connected scan.
 pwnkit ships an MCP server over stdio:
 
 ```bash
-npx -y pwnkit@latest mcp-server
+node dist/pwnkit.js mcp-server
 ```
 
-Use that command from an MCP-capable agent or editor. Herdr does not currently
-ship a built-in pwnkit integration target, so it should launch pwnkit through
-this MCP boundary or a managed terminal pane until a native Herdr adapter lands.
+Run that command from a built source checkout in an MCP-capable agent or editor.
+Herdr does not currently ship a built-in pwnkit integration target, so it should
+launch pwnkit through this MCP boundary or a managed terminal pane until a
+native Herdr adapter lands.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/0sec-labs/0sec.git"
+    "url": "git+https://github.com/0sec-labs/0sec.git"
   },
   "license": "MIT OR Apache-2.0",
   "engines": {


### PR DESCRIPTION
## Scope
- remove the unsupported `npx pwnkit@latest` install path from README
- use the built source checkout for the MCP example
- fix package repository metadata to the HTTPS public repository URL

## Verification
- `node --check scripts/create-public-source-export.mjs`
- `git diff --check`
- package metadata parsed and checked for `MIT OR Apache-2.0` plus the HTTPS repository URL

This does not claim or publish the unclaimed npm namespace. Registry publication remains a separately authorized release action.