### PR TITLE
fix(release): remove unclaimed npm install path

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,3 @@
-pwnkit is dual-licensed under MIT OR Apache-2.0, at your option.
-This file contains the Apache-2.0 terms. See LICENSE-MIT for the MIT terms.
-
 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/README.md
+++ b/README.md
@@ -34,9 +34,12 @@ continuing.
 Use pwnkit only on systems and code you own or are explicitly authorized to
 test. It is not a substitute for a written testing scope.
 
-## Install
+## Install from source
 
 ### Source
+
+`pwnkit` is not published to npm yet. Do not run `npx pwnkit` or install an
+unverified package with that name.
 
 ```bash
 git clone https://github.com/0sec-labs/0sec.git
@@ -79,16 +82,13 @@ environment and read each command's help before a connected scan.
 
 ## MCP integration
 
-pwnkit ships an MCP server over stdio:
+After building from source, run the bundled MCP server over stdio:
 
 ```bash
 node dist/pwnkit.js mcp-server
 ```
 
-Run that command from a built source checkout in an MCP-capable agent or editor.
-Herdr does not currently ship a built-in pwnkit integration target, so it should
-launch pwnkit through this MCP boundary or a managed terminal pane until a
-native Herdr adapter lands.
+Use that command from an MCP-capable agent or editor.
 
 ## Development
 
@@ -115,5 +115,6 @@ Report vulnerabilities in pwnkit through
 
 ## License
 
-[MIT OR Apache-2.0](LICENSE). See [LICENSE-MIT](LICENSE-MIT) for the MIT
-terms. Copyright 2026 0sec Labs.
+pwnkit is dual-licensed under MIT OR Apache-2.0, at your option. See
+[LICENSE](LICENSE) for the Apache-2.0 terms and [LICENSE-MIT](LICENSE-MIT) for
+the MIT terms. Copyright 2026 0sec Labs.

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "prompt-injection"
   ],
   "author": "0sec Labs",
-  "homepage": "https://0sec.ai",
+  "homepage": "https://0.security",
   "bugs": {
-    "url": "https://0sec.ai/contact"
+    "url": "https://0.security/contact"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Scope
Remove public instructions to run an unclaimed `pwnkit` npm package. Point package metadata at the public repository and make the Apache license text recognizable.

## Verification
- `pnpm build`
- `node dist/pwnkit.js --help`

Registry publication, GHCR pruning, credential rotation, and package visibility remain deliberately out of scope.