### PR TITLE
fix(craft): retain four-turn reachability evidence budget

### DIFF
--- a/packages/core/src/stages/craft-scan.test.ts
+++ b/packages/core/src/stages/craft-scan.test.ts
@@ -19,9 +19,9 @@ afterEach(() => {
 
 describe("craftStepBudget", () => {
   it("reserves trigger-testing time in a short canary while preserving the long-run threshold", () => {
-    expect(craftStepBudget(15)).toEqual({ reachabilityStepCap: 3, firstSelfTestStep: 6 });
+    expect(craftStepBudget(15)).toEqual({ reachabilityStepCap: 4, firstSelfTestStep: 6 });
     expect(craftStepBudget(40)).toEqual({ reachabilityStepCap: 4, firstSelfTestStep: 18 });
-    expect(craftStepBudget(5)).toEqual({ reachabilityStepCap: 1, firstSelfTestStep: 2 });
+    expect(craftStepBudget(5)).toEqual({ reachabilityStepCap: 4, firstSelfTestStep: 5 });
   });
 });
 

--- a/packages/core/src/stages/craft-scan.ts
+++ b/packages/core/src/stages/craft-scan.ts
@@ -295,17 +295,17 @@ function nextCraftCallUpperBoundUsd(
 }
 
 /**
- * Reserve enough of a bounded trajectory for test-and-refine work. The old
- * fixed threshold of 18 was correct only for long runs: a 15-step CyberGym
- * canary could spend almost its entire budget reading source before its first
- * candidate. Keep the long-run threshold stable while scaling short runs.
+ * Reserve enough of a bounded trajectory for test-and-refine work while
+ * retaining four source-evidence turns before the trigger stage. The
+ * first-self-test deadline scales for short runs; the reachability minimum is
+ * an evidence contract, not a time budget.
  */
 export function craftStepBudget(maxSteps: number): {
   reachabilityStepCap: number;
   firstSelfTestStep: number;
 } {
   const boundedSteps = Math.max(1, Math.floor(maxSteps));
-  const reachabilityStepCap = Math.min(4, Math.max(1, Math.floor(boundedSteps * 0.25)));
+  const reachabilityStepCap = 4;
   const firstSelfTestStep = Math.min(
     18,
     Math.max(reachabilityStepCap + 1, Math.floor(boundedSteps * 0.45)),


### PR DESCRIPTION
Restores the established four source-evidence turns before the craft stage may advance to trigger. The public cutover accidentally scaled this cap to three for a 15-step run, breaking the identity submission gate.\n\nValidation:\n- pnpm build\n- pnpm test:public (400 files / 6,383 tests passed; 3 files / 14 tests skipped)