### PR TITLE
fix(core): use Responses for native Luna tools

### DIFF
--- a/packages/core/src/runtime/llm-api.test.ts
+++ b/packages/core/src/runtime/llm-api.test.ts
@@ -220,6 +220,26 @@ describe("LlmApiRuntime provider detection", () => {
     expect((luna as any).wireApi).toBe("chat_completions");
   });
 
+  it("uses Responses wire format for direct OpenAI GPT-5.6 Luna tool calls", () => {
+    // Test fixture, literal non-secret key.
+    // foxguard: ignore[js/no-hardcoded-secret]
+    process.env.OPENAI_API_KEY = "openai-key-123";
+    process.env["0SEC_MODEL"] = "gpt-5.6-luna";
+    process.env["0SEC_SELECTED_PROVIDER"] = "openai";
+
+    const luna = new LlmApiRuntime({ type: "api", timeout: 5000 });
+    // Provider-selection tests inspect stable private runtime state directly.
+    const resolved = luna as unknown as {
+      provider: string;
+      model: string;
+      wireApi: string;
+    };
+
+    expect(resolved.provider).toBe("openai");
+    expect(resolved.model).toBe("gpt-5.6-luna");
+    expect(resolved.wireApi).toBe("responses");
+  });
+
   it("detects provider from explicit config key prefix", () => {
     const rt1 = new LlmApiRuntime({ type: "api", timeout: 5000, apiKey: "sk-or-cfg" });
     expect((rt1 as any).provider).toBe("openrouter");

--- a/packages/core/src/runtime/llm-api.ts
+++ b/packages/core/src/runtime/llm-api.ts
@@ -1554,15 +1554,15 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
       this.model = requestedModel ?? detected.defaultModel;
     }
 
-    // Azure GPT-5.6 Sol rejects function tools on /chat/completions even
-    // with reasoning_effort="none". The same deployment supports tools on
-    // /responses, so upgrade only this exact Azure deployment. Other Azure
-    // models keep the operator-selected wire API.
-    if (
-      this.provider === "azure"
-      && this.model.toLowerCase() === "gpt-5.6-sol"
-      && this.wireApi === "chat_completions"
-    ) {
+    // These deployments reject function tools plus reasoning_effort on
+    // /chat/completions. The Responses endpoint supports the agent loop, so
+    // upgrade only the exact provider/model pairs rather than changing every
+    // OpenAI-compatible deployment's requested wire API.
+    const normalizedModel = this.model.toLowerCase();
+    const requiresResponses =
+      (this.provider === "azure" && normalizedModel === "gpt-5.6-sol") ||
+      (this.provider === "openai" && normalizedModel === "gpt-5.6-luna");
+    if (requiresResponses && this.wireApi === "chat_completions") {
       this.wireApi = "responses";
     }
 


### PR DESCRIPTION
## Problem
The repaired 0cloud E2E now transports `gpt-5.6-luna` correctly, exposing OpenAI's actual response: function tools with reasoning effort are rejected on `/v1/chat/completions` for this model.

## Change
Route direct OpenAI `gpt-5.6-luna` to the Responses API when the configured wire API is chat completions. Keep Azure Sol's existing narrow upgrade and every other provider/model unchanged.

## Verification
- `pnpm --filter @0sec/core test -- src/runtime/llm-api.test.ts` — 88 passed, 1 skipped.
- Built `@0sec/shared`, `@0sec/db`, `@0sec/templates`, and `@0sec/llm-redteam`; then `pnpm --filter @0sec/core exec tsc --noEmit`.
- `pnpm --filter @0sec/core build`.

The next managed kernel smoke must use the Responses route and emit an agent turn; this is a direct response to the provider's 400 diagnostic.