### PR TITLE
feat(provider): add OpenCode support

### DIFF
--- a/docs/src/content/docs/api-keys.md
+++ b/docs/src/content/docs/api-keys.md
@@ -14,6 +14,7 @@ as environment variables.
 | **Alibaba Qwen** | `QWEN_API_KEY` | Use `--model qwen3.8-max` or `0SEC_MODEL=qwen3.8-max`. Uses Alibaba Model Studio's OpenAI-compatible endpoint. |
 | **Moonshot Kimi** | `KIMI_API_KEY` | Use `--model k3`. Uses Moonshot's Anthropic-compatible Coding endpoint. |
 | **xAI Grok** | `XAI_API_KEY` | Use `--model grok-4.6`. Uses xAI's OpenAI-compatible endpoint. Override the host with `XAI_BASE_URL`. Cost note: our price table carries xAI's short-context rates, so spend on prompts over 200k tokens is under-reported — reconcile against the xAI console. |
+| **OpenCode Zen** | `OPENCODE_API_KEY` | Use `--model muse-spark-1.3-contributor-free` (Responses wire) or `--model mimo-v2.5-free` (chat/completions wire), or `opencode/<model-id>`. Uses OpenCode Zen's OpenAI-compatible gateway, which serves GPT/Grok/Muse Spark on `/responses` and the rest of the catalog on `/chat/completions`. Override the host with `OPENCODE_BASE_URL`. |
 | **ChatGPT Codex** | `0SEC_CHATGPT_ACCESS_TOKEN`, `0SEC_CHATGPT_OAUTH_REFRESH_TOKEN` | OAuth subscription auth, not an API key. Both tokens are accepted; the access token is read first, the refresh token is refreshed on demand. This is the one provider that can also authenticate from a file — see [ChatGPT Codex authentication](#chatgpt-codex-authentication) below. |
 | **DeepSeek** | `DEEPSEEK_API_KEY` | Direct DeepSeek API access. Endpoint override: `DEEPSEEK_BASE_URL`. |
 | **OpenRouter** | `OPENROUTER_API_KEY` | Access to many hosted model families through one API. |
@@ -21,7 +22,7 @@ as environment variables.
 | **Azure OpenAI** | `AZURE_OPENAI_API_KEY` | Azure-hosted OpenAI models. See [Azure configuration](#azure-openai-configuration) below for additional settings. |
 | **OpenAI** | `OPENAI_API_KEY` | Direct access to GPT models. Endpoint override: `OPENAI_BASE_URL`. |
 
-These ten are the only providers the runtime detects from the environment. Model
+These eleven are the only providers the runtime detects from the environment. Model
 families with no direct path (Google, Meta, Mistral) are reachable through
 OpenRouter instead.
 
@@ -34,6 +35,8 @@ when more than one credential is present.
 - `glm-*` / `z-ai/*` → Z.ai
 - `qwen*` → Alibaba Qwen
 - `k3` / `kimi*` → Moonshot Kimi
+- `grok*` / `xai/*` → xAI Grok
+- `muse-spark*` / `mimo*` / `ling*` / `big-pickle` / `nemotron*` / `minimax*` / `opencode/*` → OpenCode Zen
 - `claude*` / `anthropic/*` → Anthropic, then OpenRouter when direct Anthropic
   credentials are absent
 - `gpt-*` / `o*` → ChatGPT Codex subscription when configured, otherwise
@@ -133,7 +136,7 @@ Run `/providers` first to confirm the provider is configured.
 
 Use OpenRouter to reach a model family with no direct provider credential. It's
 not required for Z.ai GLM, Alibaba Qwen, Moonshot Kimi, Anthropic, OpenAI, Azure,
-or DeepSeek.
+OpenCode Zen, or DeepSeek.
 
 ## Azure OpenAI configuration
 

--- a/docs/src/content/docs/api-keys.md
+++ b/docs/src/content/docs/api-keys.md
@@ -14,7 +14,7 @@ as environment variables.
 | **Alibaba Qwen** | `QWEN_API_KEY` | Use `--model qwen3.8-max` or `0SEC_MODEL=qwen3.8-max`. Uses Alibaba Model Studio's OpenAI-compatible endpoint. |
 | **Moonshot Kimi** | `KIMI_API_KEY` | Use `--model k3`. Uses Moonshot's Anthropic-compatible Coding endpoint. |
 | **xAI Grok** | `XAI_API_KEY` | Use `--model grok-4.6`. Uses xAI's OpenAI-compatible endpoint. Override the host with `XAI_BASE_URL`. Cost note: our price table carries xAI's short-context rates, so spend on prompts over 200k tokens is under-reported — reconcile against the xAI console. |
-| **OpenCode Zen** | `OPENCODE_API_KEY` | Use `--model muse-spark-1.3-contributor-free` (Responses wire) or `--model mimo-v2.5-free` (chat/completions wire), or `opencode/<model-id>`. Uses OpenCode Zen's OpenAI-compatible gateway, which serves GPT/Grok/Muse Spark on `/responses` and the rest of the catalog on `/chat/completions`. Override the host with `OPENCODE_BASE_URL`. |
+| **OpenCode Zen** | `OPENCODE_API_KEY` | Use `--model muse-spark-1.3-contributor-free`, or explicitly select `opencode/<model-id>`. Zen preserves each upstream protocol: GPT/Grok/Muse Spark use Responses, Claude/Qwen use Messages, Gemini uses Google `generateContent`, and DeepSeek/GLM/Kimi/MiniMax plus the free tier use chat completions. Override the host with `OPENCODE_BASE_URL`. |
 | **ChatGPT Codex** | `0SEC_CHATGPT_ACCESS_TOKEN`, `0SEC_CHATGPT_OAUTH_REFRESH_TOKEN` | OAuth subscription auth, not an API key. Both tokens are accepted; the access token is read first, the refresh token is refreshed on demand. This is the one provider that can also authenticate from a file — see [ChatGPT Codex authentication](#chatgpt-codex-authentication) below. |
 | **DeepSeek** | `DEEPSEEK_API_KEY` | Direct DeepSeek API access. Endpoint override: `DEEPSEEK_BASE_URL`. |
 | **OpenRouter** | `OPENROUTER_API_KEY` | Access to many hosted model families through one API. |
@@ -22,9 +22,10 @@ as environment variables.
 | **Azure OpenAI** | `AZURE_OPENAI_API_KEY` | Azure-hosted OpenAI models. See [Azure configuration](#azure-openai-configuration) below for additional settings. |
 | **OpenAI** | `OPENAI_API_KEY` | Direct access to GPT models. Endpoint override: `OPENAI_BASE_URL`. |
 
-These eleven are the only providers the runtime detects from the environment. Model
-families with no direct path (Google, Meta, Mistral) are reachable through
-OpenRouter instead.
+These eleven are the only providers the runtime detects from the environment.
+Model families with no direct path (Meta, Mistral) are reachable through
+OpenRouter. Gemini is also reachable through `opencode/gemini-*` when
+`OPENCODE_API_KEY` is configured.
 
 ## Model routing
 
@@ -36,7 +37,8 @@ when more than one credential is present.
 - `qwen*` → Alibaba Qwen
 - `k3` / `kimi*` → Moonshot Kimi
 - `grok*` / `xai/*` → xAI Grok
-- `muse-spark*` / `mimo*` / `ling*` / `big-pickle` / `nemotron*` / `minimax*` / `opencode/*` → OpenCode Zen
+- `muse-spark*` / `mimo*` / `ling*` / `big-pickle` / `nemotron*` / `minimax*` → OpenCode Zen
+- `opencode/<model-id>` → OpenCode Zen, using that model family's documented wire
 - `claude*` / `anthropic/*` → Anthropic, then OpenRouter when direct Anthropic
   credentials are absent
 - `gpt-*` / `o*` → ChatGPT Codex subscription when configured, otherwise

--- a/packages/cli/src/tui/connection-recovery.test.ts
+++ b/packages/cli/src/tui/connection-recovery.test.ts
@@ -22,6 +22,7 @@ describe("connectionRecoveryForError", () => {
       ["Moonshot Kimi API error", "kimi"],
       ["Alibaba Model Studio API error", "qwen"],
       ["xAI Grok API error", "xai"],
+      ["OpenCode Zen API error", "opencode"],
       ["OpenAI API error: invalid key", "openai"],
     ]) {
       expect(connectionRecoveryForError(error)).toMatchObject({ providerId });

--- a/packages/cli/src/tui/connection-recovery.ts
+++ b/packages/cli/src/tui/connection-recovery.ts
@@ -76,6 +76,13 @@ export function connectionRecoveryForError(error: string): ConnectionRecovery | 
       detail,
     };
   }
+  if (/opencode|\bzen\b/i.test(detail)) {
+    return {
+      providerId: "opencode",
+      title: "OpenCode Zen credentials need attention",
+      detail,
+    };
+  }
   if (/openai|api key|api_key/i.test(detail)) {
     return {
       providerId: "openai",

--- a/packages/cli/src/tui/provider-status.test.ts
+++ b/packages/cli/src/tui/provider-status.test.ts
@@ -49,6 +49,7 @@ describe("PROVIDERS", () => {
         "deepseek",
         "kimi",
         "openai",
+        "opencode",
         "openrouter",
         "qwen",
         "xai",

--- a/packages/cli/src/tui/provider-status.ts
+++ b/packages/cli/src/tui/provider-status.ts
@@ -124,6 +124,13 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     hint: "set XAI_API_KEY from console.x.ai (endpoint override: XAI_BASE_URL)",
   },
   {
+    id: "opencode",
+    label: "OpenCode Zen",
+    auth: "api-key",
+    envVars: ["OPENCODE_API_KEY"],
+    hint: "set OPENCODE_API_KEY from opencode.ai/auth (endpoint override: OPENCODE_BASE_URL)",
+  },
+  {
     id: "anthropic",
     label: "Anthropic",
     auth: "api-key",

--- a/packages/core/src/agent/cost.test.ts
+++ b/packages/core/src/agent/cost.test.ts
@@ -52,8 +52,25 @@ describe("estimateCost", () => {
       .toBeCloseTo(1.4 + 4.4, 5);
   });
 
-  it("prices Kimi K3 flat-rate coding models (incl. the [1m] context suffix)", () => {
-    // Kimi K3 flat-rate estimate: $3/M in, $15/M out.
+  it("prices the OpenCode Zen free tier at zero, not the default rate", () => {
+    // Free while the Zen free period lasts. Pinned so an OSS pricing refresh
+    // (OSS overlays MANUAL) silently re-pricing one of these can never pass.
+    for (const model of [
+      "muse-spark-1.3-contributor-free",
+      "muse-spark-1.2-contributor-free",
+      "mimo-v2.5-free",
+      "ling-3.0-flash-fin-free",
+      "big-pickle",
+      "nemotron-3-ultra-free",
+      "nemotron-3.5-lightning-free",
+    ]) {
+      expect(getRates(model)).toEqual({ input: 0, output: 0 });
+      expect(estimateCost({ inputTokens: 1_000_000, outputTokens: 500_000 }, model)).toBe(0);
+    }
+    expect(estimateCost({ inputTokens: 1_000_000, outputTokens: 0 }, "opencode/mimo-v2.5-free")).toBe(0);
+  });
+
+  it("prices Kimi K3 flat-rate coding models (incl. the [1m] context suffix)", () => {    // Kimi K3 flat-rate estimate: $3/M in, $15/M out.
     expect(estimateCost({ inputTokens: 1_000_000, outputTokens: 1_000_000 }, "k3"))
       .toBeCloseTo(3.0 + 15.0, 5);
     // The [1m] long-context variant is priced explicitly (normalizeModel does
@@ -215,6 +232,7 @@ describe("modelProvider", () => {
     expect(modelProvider("z-ai/glm-5.1")).toBe("z-ai");
     expect(modelProvider("kimi/k3")).toBe("kimi");
     expect(modelProvider("moonshot/k3")).toBe("kimi");
+    expect(modelProvider("opencode/mimo-v2.5-free")).toBe("opencode");
   });
 
   it("falls back to family-based detection for bare model names", () => {
@@ -230,6 +248,11 @@ describe("modelProvider", () => {
     expect(modelProvider("k3")).toBe("kimi");
     expect(modelProvider("k3[1m]")).toBe("kimi");
     expect(modelProvider("kimi-for-coding")).toBe("kimi");
+    expect(modelProvider("muse-spark-1.3-contributor-free")).toBe("opencode");
+    expect(modelProvider("mimo-v2.5-free")).toBe("opencode");
+    expect(modelProvider("ling-3.0-flash-fin-free")).toBe("opencode");
+    expect(modelProvider("big-pickle")).toBe("opencode");
+    expect(modelProvider("nemotron-3-ultra-free")).toBe("opencode");
   });
 
   it("returns 'unknown' for empty / unrecognisable model ids", () => {

--- a/packages/core/src/agent/cost.test.ts
+++ b/packages/core/src/agent/cost.test.ts
@@ -57,7 +57,6 @@ describe("estimateCost", () => {
     // (OSS overlays MANUAL) silently re-pricing one of these can never pass.
     for (const model of [
       "muse-spark-1.3-contributor-free",
-      "muse-spark-1.2-contributor-free",
       "mimo-v2.5-free",
       "ling-3.0-flash-fin-free",
       "big-pickle",
@@ -70,7 +69,8 @@ describe("estimateCost", () => {
     expect(estimateCost({ inputTokens: 1_000_000, outputTokens: 0 }, "opencode/mimo-v2.5-free")).toBe(0);
   });
 
-  it("prices Kimi K3 flat-rate coding models (incl. the [1m] context suffix)", () => {    // Kimi K3 flat-rate estimate: $3/M in, $15/M out.
+  it("prices Kimi K3 flat-rate coding models (incl. the [1m] context suffix)", () => {
+    // Kimi K3 flat-rate estimate: $3/M in, $15/M out.
     expect(estimateCost({ inputTokens: 1_000_000, outputTokens: 1_000_000 }, "k3"))
       .toBeCloseTo(3.0 + 15.0, 5);
     // The [1m] long-context variant is priced explicitly (normalizeModel does

--- a/packages/core/src/runtime/llm-api.test.ts
+++ b/packages/core/src/runtime/llm-api.test.ts
@@ -43,6 +43,8 @@ describe("LlmApiRuntime provider detection", () => {
     delete process.env.Z_AI_BASE_URL;
     delete process.env.XAI_API_KEY;
     delete process.env.XAI_BASE_URL;
+    delete process.env.OPENCODE_API_KEY;
+    delete process.env.OPENCODE_BASE_URL;
     delete process.env["0SEC_MODEL"];
     delete process.env["0SEC_SELECTED_PROVIDER"];
     delete process.env["0SEC_FORCE_PROVIDER"];
@@ -322,8 +324,7 @@ describe("LlmApiRuntime provider detection", () => {
     expect((rt as any).baseUrl).toBe("https://xai.example/v1");
   });
 
-  it("places xai ahead of the Anthropic final fallback, and routes per model pick", () => {
-    // xai joins z-ai/kimi/qwen as an explicit opt-in tried BEFORE Anthropic,
+  it("places xai ahead of the Anthropic final fallback, and routes per model pick", () => {    // xai joins z-ai/kimi/qwen as an explicit opt-in tried BEFORE Anthropic,
     // so Anthropic stays the last-resort fallback. With both keys present a
     // bare run therefore resolves to xai, while an explicit claude pick still
     // routes per-call to Anthropic.
@@ -335,6 +336,56 @@ describe("LlmApiRuntime provider detection", () => {
     expect((bare as any).provider).toBe("xai");
     const picked = new LlmApiRuntime({ type: "api", timeout: 5000, model: "grok-4.6" });
     expect((picked as any).provider).toBe("xai");
+    const claude = new LlmApiRuntime({ type: "api", timeout: 5000, model: "claude-sonnet-4-6" });
+    expect((claude as any).provider).toBe("anthropic");
+  });
+
+  it("selects OpenCode Zen via OPENCODE_API_KEY with Muse Spark defaults on the Responses wire", () => {
+    // Test fixture, literal non-secret key.
+    // foxguard: ignore[js/no-hardcoded-secret]
+    process.env.OPENCODE_API_KEY = "zen-test";
+    const rt = new LlmApiRuntime({ type: "api", timeout: 5000 });
+    expect((rt as any).provider).toBe("opencode");
+    expect((rt as any).model).toBe("muse-spark-1.3-contributor-free");
+    expect((rt as any).baseUrl).toBe("https://opencode.ai/zen/v1");
+    expect((rt as any).wireApi).toBe("responses");
+    const headers = (rt as any).buildHeaders();
+    expect(headers["Authorization"]).toBe("Bearer zen-test");
+    expect(headers["x-api-key"]).toBeUndefined();
+    expect((rt as any).buildUrl()).toBe("https://opencode.ai/zen/v1/responses");
+  });
+
+  it("routes mimo/ling picks to opencode on the chat/completions wire, honoring OPENCODE_BASE_URL", () => {
+    // Test fixture, literal non-secret key.
+    // foxguard: ignore[js/no-hardcoded-secret]
+    process.env.OPENCODE_API_KEY = "zen-test";
+    process.env.OPENCODE_BASE_URL = "https://zen.example/v1";
+    process.env["0SEC_MODEL"] = "mimo-v2.5-free";
+    const rt = new LlmApiRuntime({ type: "api", timeout: 5000 });
+    expect((rt as any).provider).toBe("opencode");
+    expect((rt as any).model).toBe("mimo-v2.5-free");
+    expect((rt as any).baseUrl).toBe("https://zen.example/v1");
+    expect((rt as any).wireApi).toBe("chat_completions");
+    expect((rt as any).buildUrl()).toBe("https://zen.example/v1/chat/completions");
+  });
+
+  it("places opencode ahead of the Anthropic final fallback, and routes per model pick", () => {
+    // opencode joins z-ai/kimi/qwen/xai as an explicit opt-in tried BEFORE
+    // Anthropic, so Anthropic stays the last-resort fallback. With both keys
+    // present a bare run therefore resolves to opencode, while an explicit
+    // claude pick still routes per-call to Anthropic.
+    // foxguard: ignore[js/no-hardcoded-secret]
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+    // foxguard: ignore[js/no-hardcoded-secret]
+    process.env.OPENCODE_API_KEY = "zen-test";
+    const bare = new LlmApiRuntime({ type: "api", timeout: 5000 });
+    expect((bare as any).provider).toBe("opencode");
+    const mimo = new LlmApiRuntime({ type: "api", timeout: 5000, model: "mimo-v2.5-free" });
+    expect((mimo as any).provider).toBe("opencode");
+    expect((mimo as any).wireApi).toBe("chat_completions");
+    const spark = new LlmApiRuntime({ type: "api", timeout: 5000, model: "muse-spark-1.3-contributor-free" });
+    expect((spark as any).provider).toBe("opencode");
+    expect((spark as any).wireApi).toBe("responses");
     const claude = new LlmApiRuntime({ type: "api", timeout: 5000, model: "claude-sonnet-4-6" });
     expect((claude as any).provider).toBe("anthropic");
   });
@@ -1794,6 +1845,18 @@ describe("resolveFailoverProvider", () => {
     const cfg = resolveFailoverProvider("anthropic", "claude-sonnet-4-20250514");
     expect(cfg).not.toBeUndefined();
     expect(cfg!.apiKey).toBe("sk-ant-fallback");
+  });
+
+  it("resolves opencode with a per-model wire (responses for spark, chat for mimo)", () => {
+    process.env.OPENCODE_API_KEY = "zen-key";
+    const spark = resolveFailoverProvider("opencode", "muse-spark-1.3-contributor-free");
+    expect(spark).not.toBeUndefined();
+    expect(spark!.apiKey).toBe("zen-key");
+    expect(spark!.baseUrl).toBe("https://opencode.ai/zen/v1");
+    expect(spark!.wireApi).toBe("responses");
+    const mimo = resolveFailoverProvider("opencode", "mimo-v2.5-free");
+    expect(mimo).not.toBeUndefined();
+    expect(mimo!.wireApi).toBe("chat_completions");
   });
 });
 

--- a/packages/core/src/runtime/llm-api.test.ts
+++ b/packages/core/src/runtime/llm-api.test.ts
@@ -324,7 +324,8 @@ describe("LlmApiRuntime provider detection", () => {
     expect((rt as any).baseUrl).toBe("https://xai.example/v1");
   });
 
-  it("places xai ahead of the Anthropic final fallback, and routes per model pick", () => {    // xai joins z-ai/kimi/qwen as an explicit opt-in tried BEFORE Anthropic,
+  it("places xai ahead of the Anthropic final fallback, and routes per model pick", () => {
+    // xai joins z-ai/kimi/qwen as an explicit opt-in tried BEFORE Anthropic,
     // so Anthropic stays the last-resort fallback. With both keys present a
     // bare run therefore resolves to xai, while an explicit claude pick still
     // routes per-call to Anthropic.
@@ -360,13 +361,52 @@ describe("LlmApiRuntime provider detection", () => {
     // foxguard: ignore[js/no-hardcoded-secret]
     process.env.OPENCODE_API_KEY = "zen-test";
     process.env.OPENCODE_BASE_URL = "https://zen.example/v1";
-    process.env["0SEC_MODEL"] = "mimo-v2.5-free";
+    process.env["0SEC_MODEL"] = "opencode/mimo-v2.5-free";
     const rt = new LlmApiRuntime({ type: "api", timeout: 5000 });
     expect((rt as any).provider).toBe("opencode");
     expect((rt as any).model).toBe("mimo-v2.5-free");
     expect((rt as any).baseUrl).toBe("https://zen.example/v1");
     expect((rt as any).wireApi).toBe("chat_completions");
     expect((rt as any).buildUrl()).toBe("https://zen.example/v1/chat/completions");
+  });
+
+  it("routes prefixed Claude and Gemini models to their native Zen wires", () => {
+    // Test fixture, literal non-secret key.
+    // foxguard: ignore[js/no-hardcoded-secret]
+    process.env.OPENCODE_API_KEY = "zen-test";
+    const claude = new LlmApiRuntime({
+      type: "api",
+      timeout: 5000,
+      model: "opencode/claude-opus-4-7",
+    });
+    const claudeWire = claude as unknown as {
+      model: string;
+      wireApi: string;
+      buildHeaders(): Record<string, string>;
+      buildUrl(): string;
+    };
+    expect(claudeWire.model).toBe("claude-opus-4-7");
+    expect(claudeWire.wireApi).toBe("anthropic_messages");
+    expect(claudeWire.buildHeaders()["x-api-key"]).toBe("zen-test");
+    expect(claudeWire.buildUrl()).toBe("https://opencode.ai/zen/v1/messages");
+
+    const gemini = new LlmApiRuntime({
+      type: "api",
+      timeout: 5000,
+      model: "opencode/gemini-3.8-flash",
+    });
+    const geminiWire = gemini as unknown as {
+      model: string;
+      wireApi: string;
+      buildHeaders(): Record<string, string>;
+      buildUrl(): string;
+    };
+    expect(geminiWire.model).toBe("gemini-3.8-flash");
+    expect(geminiWire.wireApi).toBe("google_generate_content");
+    expect(geminiWire.buildHeaders()["x-goog-api-key"]).toBe("zen-test");
+    expect(geminiWire.buildUrl()).toBe(
+      "https://opencode.ai/zen/v1/models/gemini-3.8-flash:generateContent",
+    );
   });
 
   it("places opencode ahead of the Anthropic final fallback, and routes per model pick", () => {
@@ -755,6 +795,201 @@ describe("LlmApiRuntime chat completions format", () => {
     (rt as any).reasoningEffort = "low";
     await rt.execute("prompt");
     expect(capturedBody.reasoning_effort).toBe("low");
+  });
+});
+
+// ── OpenCode Gemini generateContent format ──
+
+type GoogleRuntimeInternals = {
+  provider: string;
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  wireApi: string;
+};
+
+function googleRuntime(): LlmApiRuntime {
+  const runtime = new LlmApiRuntime({ type: "api", timeout: 5000 });
+  // Test-only access to the selected runtime transport.
+  const internals = runtime as unknown as GoogleRuntimeInternals;
+  internals.provider = "opencode";
+  internals.apiKey = "zen-test";
+  internals.baseUrl = "https://opencode.ai/zen/v1";
+  internals.model = "gemini-3.8-flash";
+  internals.wireApi = "google_generate_content";
+  return runtime;
+}
+
+describe("LlmApiRuntime OpenCode Gemini format", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("preserves Gemini function-call metadata through a tool continuation", async () => {
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const requestUrls: string[] = [];
+    const requestHeaders: Headers[] = [];
+    const responses = [
+      {
+        candidates: [{
+          content: {
+            parts: [{
+              functionCall: {
+                id: "upstream-call-1",
+                name: "read_file",
+                args: { path: "README.md" },
+                thoughtSignature: "signed-thought",
+              },
+            }],
+          },
+          finishReason: "STOP",
+        }],
+        usageMetadata: { promptTokenCount: 7, candidatesTokenCount: 3 },
+      },
+      {
+        candidates: [{
+          content: { parts: [{ text: "README inspected." }] },
+          finishReason: "STOP",
+        }],
+        usageMetadata: { promptTokenCount: 11, candidatesTokenCount: 4 },
+      },
+    ];
+    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const parsed = JSON.parse(String(init?.body)) as unknown;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("expected an object request body");
+      }
+      requestBodies.push(parsed as Record<string, unknown>);
+      requestUrls.push(String(url));
+      requestHeaders.push(new Headers(init?.headers));
+      const response = responses.shift();
+      if (!response) throw new Error("unexpected extra request");
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify(response),
+      } as unknown as Response;
+    }));
+
+    const runtime = googleRuntime();
+    const tools = [{
+      name: "read_file",
+      description: "Read a file",
+      input_schema: {
+        type: "object" as const,
+        properties: { path: { type: "string" } },
+        required: ["path"],
+      },
+    }];
+    const first = await runtime.executeNative(
+      "Inspect the repository.",
+      [{ role: "user", content: [{ type: "text", text: "Read README.md" }] }],
+      tools,
+    );
+
+    expect(requestUrls[0]).toBe(
+      "https://opencode.ai/zen/v1/models/gemini-3.8-flash:generateContent",
+    );
+    expect(requestHeaders[0]?.get("x-goog-api-key")).toBe("zen-test");
+    expect(requestBodies[0]).toMatchObject({
+      systemInstruction: { parts: [{ text: "Inspect the repository." }] },
+      contents: [{ role: "user", parts: [{ text: "Read README.md" }] }],
+      tools: [{
+        functionDeclarations: [{
+          name: "read_file",
+          parametersJsonSchema: { type: "object" },
+        }],
+      }],
+    });
+    expect(first).toMatchObject({
+      stopReason: "tool_use",
+      usage: { inputTokens: 7, outputTokens: 3 },
+      content: [{
+        type: "tool_use",
+        id: "upstream-call-1",
+        name: "read_file",
+        input: { path: "README.md" },
+      }],
+    });
+    if (!first.providerRaw) throw new Error("expected Google provider metadata");
+
+    const second = await runtime.executeNative(
+      "Inspect the repository.",
+      [
+        { role: "user", content: [{ type: "text", text: "Read README.md" }] },
+        { role: "assistant", content: first.content, providerRaw: first.providerRaw },
+        {
+          role: "user",
+          content: [{
+            type: "tool_result",
+            tool_use_id: "upstream-call-1",
+            content: "# 0sec",
+          }],
+        },
+      ],
+      tools,
+    );
+
+    expect(requestBodies[1]).toMatchObject({
+      contents: [
+        { role: "user", parts: [{ text: "Read README.md" }] },
+        {
+          role: "model",
+          parts: [{
+            functionCall: {
+              id: "upstream-call-1",
+              name: "read_file",
+              thoughtSignature: "signed-thought",
+            },
+          }],
+        },
+        {
+          role: "user",
+          parts: [{
+            functionResponse: {
+              id: "upstream-call-1",
+              name: "read_file",
+              response: { name: "read_file", content: "# 0sec" },
+            },
+          }],
+        },
+      ],
+    });
+    expect(second).toMatchObject({
+      stopReason: "end_turn",
+      content: [{ type: "text", text: "README inspected." }],
+      usage: { inputTokens: 11, outputTokens: 4 },
+    });
+  });
+
+  it("uses generateContent for legacy prompts", async () => {
+    let body: Record<string, unknown> | undefined;
+    vi.stubGlobal("fetch", vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const parsed = JSON.parse(String(init?.body)) as unknown;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("expected an object request body");
+      }
+      body = parsed as Record<string, unknown>;
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({
+          candidates: [{ content: { parts: [{ text: "legacy result" }] } }],
+        }),
+      } as unknown as Response;
+    }));
+
+    const result = await googleRuntime().execute("Summarize this.", {
+      systemPrompt: "Be concise.",
+    });
+
+    expect(body).toMatchObject({
+      systemInstruction: { parts: [{ text: "Be concise." }] },
+      contents: [{ role: "user", parts: [{ text: "Summarize this." }] }],
+      generationConfig: { maxOutputTokens: 8192 },
+    });
+    expect(result).toMatchObject({ output: "legacy result", exitCode: 0 });
   });
 });
 
@@ -1847,16 +2082,22 @@ describe("resolveFailoverProvider", () => {
     expect(cfg!.apiKey).toBe("sk-ant-fallback");
   });
 
-  it("resolves opencode with a per-model wire (responses for spark, chat for mimo)", () => {
+  it("resolves OpenCode models to their documented native wires", () => {
+    // Test fixture, literal non-secret key.
+    // foxguard: ignore[js/no-hardcoded-secret]
     process.env.OPENCODE_API_KEY = "zen-key";
     const spark = resolveFailoverProvider("opencode", "muse-spark-1.3-contributor-free");
-    expect(spark).not.toBeUndefined();
-    expect(spark!.apiKey).toBe("zen-key");
-    expect(spark!.baseUrl).toBe("https://opencode.ai/zen/v1");
-    expect(spark!.wireApi).toBe("responses");
-    const mimo = resolveFailoverProvider("opencode", "mimo-v2.5-free");
-    expect(mimo).not.toBeUndefined();
-    expect(mimo!.wireApi).toBe("chat_completions");
+    expect(spark).toMatchObject({
+      apiKey: "zen-key",
+      baseUrl: "https://opencode.ai/zen/v1",
+      wireApi: "responses",
+    });
+    expect(resolveFailoverProvider("opencode", "mimo-v2.5-free")?.wireApi)
+      .toBe("chat_completions");
+    expect(resolveFailoverProvider("opencode", "opencode/claude-opus-4-7")?.wireApi)
+      .toBe("anthropic_messages");
+    expect(resolveFailoverProvider("opencode", "opencode/gemini-3.8-flash")?.wireApi)
+      .toBe("google_generate_content");
   });
 });
 

--- a/packages/core/src/runtime/llm-api.test.ts
+++ b/packages/core/src/runtime/llm-api.test.ts
@@ -813,6 +813,8 @@ function googleRuntime(): LlmApiRuntime {
   // Test-only access to the selected runtime transport.
   const internals = runtime as unknown as GoogleRuntimeInternals;
   internals.provider = "opencode";
+  // Test fixture, literal non-secret key.
+  // foxguard: ignore[js/no-hardcoded-secret]
   internals.apiKey = "zen-test";
   internals.baseUrl = "https://opencode.ai/zen/v1";
   internals.model = "gemini-3.8-flash";

--- a/packages/core/src/runtime/llm-api.ts
+++ b/packages/core/src/runtime/llm-api.ts
@@ -701,7 +701,19 @@ const QWEN_TOKEN_PLAN_DEEPSEEK_MODEL = "deepseek-v4-flash-0731";
 const XAI_DEFAULT_BASE_URL = "https://api.x.ai/v1";
 const XAI_DEFAULT_MODEL = "grok-4.6";
 
-type ApiProvider = "openrouter" | "anthropic" | "openai" | "azure" | "deepseek" | "chatgpt-codex" | "z-ai" | "kimi" | "qwen" | "xai";
+// ── OpenCode Zen (API-key gateway, https://opencode.ai/zen/v1) ─────────────
+// ponytail: per-model wire split (muse-spark/gpt/grok→responses, rest chat); new Responses families need a regex entry.
+const OPENCODE_DEFAULT_BASE_URL = "https://opencode.ai/zen/v1";
+const OPENCODE_DEFAULT_MODEL = "muse-spark-1.3-contributor-free";
+
+/** Which Zen endpoint serves `model`. Defaults to chat so new free models work without a code change. */
+function opencodeWireApiForModel(model: string | undefined): WireApi {
+  const m = (model ?? OPENCODE_DEFAULT_MODEL).toLowerCase();
+  const bare = m.startsWith("opencode/") ? m.slice("opencode/".length) : m;
+  return /^(muse-spark|gpt-|o[1-4](?:[-_]|$)|grok|xai\/|x-ai\/)/.test(bare) ? "responses" : "chat_completions";
+}
+
+type ApiProvider = "openrouter" | "anthropic" | "openai" | "azure" | "deepseek" | "chatgpt-codex" | "z-ai" | "kimi" | "qwen" | "xai" | "opencode";
 type WireApi = "chat_completions" | "responses";
 /**
  * Azure Foundry deployment ids used by 0cloud. The worker can inject both
@@ -749,7 +761,7 @@ export function parseLlmFallbackChain(): FallbackEntry[] {
   const entries: FallbackEntry[] = [];
   const VALID_PROVIDERS: Record<string, true> = {
     openrouter: true, anthropic: true, openai: true, azure: true, deepseek: true,
-    "chatgpt-codex": true, "z-ai": true, kimi: true, qwen: true, xai: true,
+    "chatgpt-codex": true, "z-ai": true, kimi: true, qwen: true, xai: true, opencode: true,
   };
   for (const part of raw.split(",")) {
     const trimmed = part.trim();
@@ -847,6 +859,11 @@ export function resolveFailoverProvider(
       const key = process.env.XAI_API_KEY;
       if (!key) return undefined;
       return { apiKey: key, baseUrl: process.env.XAI_BASE_URL ?? XAI_DEFAULT_BASE_URL, wireApi: "chat_completions" };
+    }
+    case "opencode": {
+      const key = process.env.OPENCODE_API_KEY;
+      if (!key) return undefined;
+      return { apiKey: key, baseUrl: process.env.OPENCODE_BASE_URL ?? OPENCODE_DEFAULT_BASE_URL, wireApi: opencodeWireApiForModel(model) };
     }
   }
 }
@@ -1320,6 +1337,10 @@ function providerForModel(model: string | undefined): ApiProvider | undefined {
   if (m.startsWith("grok") || m.startsWith("xai/") || m.startsWith("x-ai/")) {
     return process.env.XAI_API_KEY ? "xai" : undefined;
   }
+  // OpenCode Zen: vendor prefix + Zen-exclusive families (no native provider).
+  if (/^(opencode\/|muse-spark|mimo|ling|big-pickle|nemotron|minimax)/.test(m)) {
+    return process.env.OPENCODE_API_KEY ? "opencode" : undefined;
+  }
   // OpenAI GPT-5 / o-series → ChatGPT-Codex subscription if present, else OpenAI.
   if (/^gpt-|^o[1-4](?:[-_]|$)/.test(m)) {
     if (process.env["0SEC_CHATGPT_ACCESS_TOKEN"] || process.env["0SEC_CHATGPT_OAUTH_REFRESH_TOKEN"]) return "chatgpt-codex";
@@ -1420,6 +1441,7 @@ function detectProvider(configApiKey?: string, preferredModel?: string): {
       "kimi",
       "qwen",
       "xai",
+      "opencode",
     ];
     if (!supported.includes(pinnedProviderRaw as ApiProvider)) {
       throw new Error(`${source} is unsupported: ${pinnedProviderRaw}`);
@@ -1484,6 +1506,9 @@ function detectProvider(configApiKey?: string, preferredModel?: string): {
     case "xai":
       return { provider: "xai", apiKey: process.env.XAI_API_KEY as string,
         baseUrl: process.env.XAI_BASE_URL ?? XAI_DEFAULT_BASE_URL, defaultModel: XAI_DEFAULT_MODEL, wireApi: "chat_completions" };
+    case "opencode":
+      return { provider: "opencode", apiKey: process.env.OPENCODE_API_KEY as string,
+        baseUrl: process.env.OPENCODE_BASE_URL ?? OPENCODE_DEFAULT_BASE_URL, defaultModel: OPENCODE_DEFAULT_MODEL, wireApi: opencodeWireApiForModel(preferredModel) };
     case "chatgpt-codex":
       return { provider: "chatgpt-codex", apiKey: "", baseUrl: CODEX_API_ENDPOINT,
         defaultModel: process.env["0SEC_MODEL"] ?? CODEX_DEFAULT_MODEL, wireApi: "responses" };
@@ -1651,6 +1676,20 @@ function detectProvider(configApiKey?: string, preferredModel?: string): {
     };
   }
 
+  // OpenCode Zen — OpenAI-compatible gateway (per-model Responses vs
+  // chat/completions wire, see opencodeWireApiForModel), same explicit-opt-in
+  // treatment as z-ai/kimi/qwen/xai, still before the Anthropic final fallback.
+  const opencodeKey = process.env.OPENCODE_API_KEY;
+  if (opencodeKey) {
+    return {
+      provider: "opencode",
+      apiKey: opencodeKey,
+      baseUrl: process.env.OPENCODE_BASE_URL ?? OPENCODE_DEFAULT_BASE_URL,
+      defaultModel: OPENCODE_DEFAULT_MODEL,
+      wireApi: opencodeWireApiForModel(preferredModel),
+    };
+  }
+
   const anthropicKey = process.env.ANTHROPIC_API_KEY;
   if (anthropicKey) {
     return {
@@ -1789,6 +1828,7 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
       this.provider === "deepseek" ||
       this.provider === "qwen" ||
       this.provider === "xai" ||
+      this.provider === "opencode" ||
       // chatgpt-codex always speaks Responses API; treat it as
       // OpenAI-compat for body-shape branching purposes (the Responses
       // wire-API code paths below already key on `wireApi === "responses"`
@@ -2012,6 +2052,7 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
       case "kimi": return "Kimi (Moonshot)";
       case "qwen": return "Qwen (Alibaba Model Studio)";
       case "xai": return "xAI (Grok)";
+      case "opencode": return "OpenCode Zen";
     }
   }
 
@@ -2027,7 +2068,8 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
       "  export Z_AI_API_KEY=...                (Z.ai GLM — flat-rate Coding Plan, Anthropic-compatible)\n" +
       "  export KIMI_API_KEY=...                (Moonshot Kimi K3 — flat-rate coding, Anthropic-compatible)\n" +
       "  export QWEN_API_KEY=...                (Alibaba Qwen — Token Plan sub, OpenAI-compatible)\n" +
-      "  export XAI_API_KEY=...                 (xAI Grok — OpenAI-compatible)"
+      "  export XAI_API_KEY=...                 (xAI Grok — OpenAI-compatible)\n" +
+      "  export OPENCODE_API_KEY=...            (OpenCode Zen — OpenAI-compatible gateway)"
     );
   }
 

--- a/packages/core/src/runtime/llm-api.ts
+++ b/packages/core/src/runtime/llm-api.ts
@@ -57,6 +57,7 @@ function safeParseJson(raw: string | null | undefined): Record<string, unknown> 
   }
 }
 
+
 /** True when persisted provider output is safe to replay as Anthropic blocks. */
 function isWireBlockArray(blocks: unknown[]): blocks is WireBlock[] {
   return blocks.every(
@@ -702,19 +703,40 @@ const XAI_DEFAULT_BASE_URL = "https://api.x.ai/v1";
 const XAI_DEFAULT_MODEL = "grok-4.6";
 
 // ── OpenCode Zen (API-key gateway, https://opencode.ai/zen/v1) ─────────────
-// ponytail: per-model wire split (muse-spark/gpt/grok→responses, rest chat); new Responses families need a regex entry.
+//
+// Zen proxies several native APIs. Route each documented model family to its
+// actual wire instead of treating the gateway as universally OpenAI-compatible:
+// Responses (GPT/Grok/Muse), Anthropic Messages (Claude/Qwen), Google
+// generateContent (Gemini), and OpenAI chat completions (the remaining
+// documented families).
 const OPENCODE_DEFAULT_BASE_URL = "https://opencode.ai/zen/v1";
 const OPENCODE_DEFAULT_MODEL = "muse-spark-1.3-contributor-free";
 
-/** Which Zen endpoint serves `model`. Defaults to chat so new free models work without a code change. */
+type WireApi =
+  | "chat_completions"
+  | "responses"
+  | "anthropic_messages"
+  | "google_generate_content";
+
+let googleFunctionCallSequence = 0;
+
+function opencodeModelId(model: string): string {
+  return model.replace(/^opencode\//i, "");
+}
+
+/** Return the documented Zen wire for a canonical or `opencode/`-prefixed model. */
 function opencodeWireApiForModel(model: string | undefined): WireApi {
-  const m = (model ?? OPENCODE_DEFAULT_MODEL).toLowerCase();
-  const bare = m.startsWith("opencode/") ? m.slice("opencode/".length) : m;
-  return /^(muse-spark|gpt-|o[1-4](?:[-_]|$)|grok|xai\/|x-ai\/)/.test(bare) ? "responses" : "chat_completions";
+  const bare = opencodeModelId(model ?? OPENCODE_DEFAULT_MODEL).toLowerCase();
+  if (/^(muse-spark|gpt-|o[1-4](?:[-_]|$)|grok)/.test(bare)) return "responses";
+  if (/^(claude|qwen)/.test(bare)) return "anthropic_messages";
+  if (/^gemini/.test(bare)) return "google_generate_content";
+  if (/^(deepseek|mimo|ling|big-pickle|nemotron|minimax|glm|kimi|k3)/.test(bare)) {
+    return "chat_completions";
+  }
+  throw new Error(`OpenCode Zen has no wire mapping for model "${bare}"`);
 }
 
 type ApiProvider = "openrouter" | "anthropic" | "openai" | "azure" | "deepseek" | "chatgpt-codex" | "z-ai" | "kimi" | "qwen" | "xai" | "opencode";
-type WireApi = "chat_completions" | "responses";
 /**
  * Azure Foundry deployment ids used by 0cloud. The worker can inject both
  * the Azure primary key and a direct-DeepSeek fallback key; route a Foundry
@@ -1676,9 +1698,9 @@ function detectProvider(configApiKey?: string, preferredModel?: string): {
     };
   }
 
-  // OpenCode Zen — OpenAI-compatible gateway (per-model Responses vs
-  // chat/completions wire, see opencodeWireApiForModel), same explicit-opt-in
-  // treatment as z-ai/kimi/qwen/xai, still before the Anthropic final fallback.
+  // OpenCode Zen — multi-wire gateway selected per model (see
+  // opencodeWireApiForModel), same explicit-opt-in treatment as z-ai/kimi/qwen/xai,
+  // still before the Anthropic final fallback.
   const opencodeKey = process.env.OPENCODE_API_KEY;
   if (opencodeKey) {
     return {
@@ -1769,6 +1791,12 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
     } else {
       this.model = requestedModel ?? detected.defaultModel;
     }
+    // `opencode/<model-id>` is a routing prefix, not an upstream model id.
+    // Strip it once the provider and wire have been selected so the gateway
+    // receives its canonical catalog ID.
+    if (this.provider === "opencode") {
+      this.model = opencodeModelId(this.model);
+    }
 
     // These deployments reject function tools plus reasoning_effort on
     // /chat/completions. The Responses endpoint supports the agent loop, so
@@ -1828,7 +1856,8 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
       this.provider === "deepseek" ||
       this.provider === "qwen" ||
       this.provider === "xai" ||
-      this.provider === "opencode" ||
+      (this.provider === "opencode" &&
+        (this.wireApi === "chat_completions" || this.wireApi === "responses")) ||
       // chatgpt-codex always speaks Responses API; treat it as
       // OpenAI-compat for body-shape branching purposes (the Responses
       // wire-API code paths below already key on `wireApi === "responses"`
@@ -1853,8 +1882,14 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
     return (
       this.provider === "anthropic" ||
       this.provider === "z-ai" ||
-      this.provider === "kimi"
+      this.provider === "kimi" ||
+      (this.provider === "opencode" && this.wireApi === "anthropic_messages")
     );
+  }
+
+  /** Whether this OpenCode Zen model uses the Google generateContent wire. */
+  private get isGoogleWire(): boolean {
+    return this.provider === "opencode" && this.wireApi === "google_generate_content";
   }
 
   /**
@@ -1886,6 +1921,12 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
         "Content-Type": "application/json",
         originator: "0sec",
         "User-Agent": `0sec/${VERSION}`,
+      };
+    }
+    if (this.isGoogleWire) {
+      return {
+        "Content-Type": "application/json",
+        "x-goog-api-key": this.apiKey,
       };
     }
     if (this.isOpenAICompat) {
@@ -1960,6 +2001,9 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
       // to it too.
       return CODEX_API_ENDPOINT;
     }
+    if (this.isGoogleWire) {
+      return `${this.baseUrl}/models/${this.model}:generateContent`;
+    }
     if (this.isOpenAICompat) {
       return `${this.baseUrl}/${this.wireApi === "responses" ? "responses" : "chat/completions"}`;
     }
@@ -1968,7 +2012,9 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
     // so an unmapped provider fails loudly instead of silently hitting
     // `/v1/messages`.
     if (this.isAnthropicWire) {
-      return `${this.baseUrl}/v1/messages`;
+      return this.provider === "opencode"
+        ? `${this.baseUrl}/messages`
+        : `${this.baseUrl}/v1/messages`;
     }
     throw new Error(`buildUrl: provider ${this.provider} is not mapped to a wire`);
   }
@@ -2010,6 +2056,76 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
 
     if (budget <= 0) return {};
     return { thinking: { type: "enabled", budget_tokens: budget } };
+  }
+
+  /** Convert the unified transcript into Gemini generateContent contents. */
+  private googleContents(messages: NativeMessage[]): Array<Record<string, unknown>> {
+    const toolNames = new Map<string, string>();
+    const upstreamCallIds = new Map<string, string>();
+    const contents: Array<Record<string, unknown>> = [];
+
+    for (const message of messages) {
+      const parts: Array<Record<string, unknown>> = [];
+      const rawParts =
+        message.role === "assistant" &&
+        message.providerRaw?.provider === this.provider &&
+        message.providerRaw.model === this.model &&
+        message.providerRaw.wireApi === this.wireApi &&
+        Array.isArray(message.providerRaw.output)
+          ? message.providerRaw.output as Array<Record<string, unknown>>
+          : undefined;
+
+      if (rawParts) {
+        const toolUses = message.content.filter(
+          (block): block is Extract<NativeContentBlock, { type: "tool_use" }> =>
+            block.type === "tool_use",
+        );
+        let toolUseIndex = 0;
+        for (const part of rawParts) {
+          const call =
+            part.functionCall && typeof part.functionCall === "object"
+              ? part.functionCall as Record<string, unknown>
+              : undefined;
+          const toolUse = call ? toolUses[toolUseIndex++] : undefined;
+          const name = typeof call?.name === "string" ? call.name : toolUse?.name;
+          if (toolUse && name) {
+            toolNames.set(toolUse.id, name);
+            if (typeof call?.id === "string") upstreamCallIds.set(toolUse.id, call.id);
+          }
+          parts.push(part);
+        }
+      } else {
+        for (const block of message.content) {
+          if (block.type === "text") {
+            parts.push({ text: block.text });
+          } else if (block.type === "tool_use") {
+            toolNames.set(block.id, block.name);
+            upstreamCallIds.set(block.id, block.id);
+            parts.push({ functionCall: { id: block.id, name: block.name, args: block.input } });
+          } else if (block.type === "tool_result") {
+            const name = toolNames.get(block.tool_use_id);
+            if (!name) {
+              throw new Error(`Google tool result ${block.tool_use_id} has no matching tool call`);
+            }
+            const upstreamId = upstreamCallIds.get(block.tool_use_id);
+            parts.push({
+              functionResponse: {
+                ...(upstreamId ? { id: upstreamId } : {}),
+                name,
+                response: {
+                  name,
+                  content: block.is_error ? `Error: ${block.content}` : block.content,
+                },
+              },
+            });
+          }
+        }
+      }
+      if (parts.length > 0) {
+        contents.push({ role: message.role === "assistant" ? "model" : "user", parts });
+      }
+    }
+    return contents;
   }
 
   /**
@@ -2069,7 +2185,7 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
       "  export KIMI_API_KEY=...                (Moonshot Kimi K3 — flat-rate coding, Anthropic-compatible)\n" +
       "  export QWEN_API_KEY=...                (Alibaba Qwen — Token Plan sub, OpenAI-compatible)\n" +
       "  export XAI_API_KEY=...                 (xAI Grok — OpenAI-compatible)\n" +
-      "  export OPENCODE_API_KEY=...            (OpenCode Zen — OpenAI-compatible gateway)"
+      "  export OPENCODE_API_KEY=...            (OpenCode Zen — multi-wire gateway)"
     );
   }
 
@@ -2185,7 +2301,7 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
         continue;
       }
       this.provider = entry.provider;
-      this.model = entry.model;
+      this.model = entry.provider === "opencode" ? opencodeModelId(entry.model) : entry.model;
       this.apiKey = cfg.apiKey;
       this.baseUrl = cfg.baseUrl;
       this.wireApi = cfg.wireApi;
@@ -2501,6 +2617,17 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
           }),
           controller.signal,
         );
+      } else if (this.isGoogleWire) {
+        res = await this.postWithRetry(
+          () => JSON.stringify({
+            ...(systemPrompt
+              ? { systemInstruction: { parts: [{ text: systemPrompt }] } }
+              : {}),
+            contents: [{ role: "user", parts: [{ text: prompt }] }],
+            generationConfig: { maxOutputTokens: NATIVE_COMPLETION_TOKEN_LIMIT },
+          }),
+          controller.signal,
+        );
       } else if (this.isAnthropicWire) {
         // Anthropic Messages API format (also serves the z-ai/GLM and
         // kimi/Moonshot providers — see `isAnthropicWire`).
@@ -2557,6 +2684,12 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
                   .map((block: Record<string, unknown>) => String(block.text ?? ""))
                   .join("\n")
               : "";
+      } else if (this.isGoogleWire) {
+        text =
+          json.candidates?.[0]?.content?.parts
+            ?.filter((part: Record<string, unknown>) => typeof part.text === "string")
+            .map((part: Record<string, unknown>) => part.text as string)
+            .join("\n") ?? "";
       } else {
         // Anthropic Messages response (also z-ai/GLM + kimi/Moonshot).
         text =
@@ -2953,6 +3086,26 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
         });
         clearTimeout(timer);
         return streamed;
+      } else if (this.isGoogleWire) {
+        const body: Record<string, unknown> = {
+          ...(system ? { systemInstruction: { parts: [{ text: system }] } } : {}),
+          contents: this.googleContents(messages),
+          generationConfig: { maxOutputTokens: NATIVE_COMPLETION_TOKEN_LIMIT },
+        };
+        if (tools.length > 0) {
+          body.tools = [{
+            functionDeclarations: tools.map((tool) => ({
+              name: tool.name,
+              description: tool.description,
+              parametersJsonSchema: tool.input_schema,
+            })),
+          }];
+        }
+        res = await this.postWithRetry(
+          () => JSON.stringify(body),
+          call.signal,
+          call,
+        );
       } else if (this.isAnthropicWire) {
         // Anthropic Messages API format (also serves the z-ai/GLM and
         // kimi/Moonshot providers — see `isAnthropicWire`).
@@ -3215,6 +3368,53 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
             // Responses `input_tokens` already includes the cached span, so
             // this is instrumentation only — see the streaming path.
             ...readResponsesCachedTokens(json.usage as Record<string, unknown>),
+          };
+        }
+      } else if (this.isGoogleWire) {
+        const candidate = json.candidates?.[0];
+        const rawParts = Array.isArray(candidate?.content?.parts)
+          ? candidate.content.parts as Array<Record<string, unknown>>
+          : [];
+        content = [];
+        if (rawParts.length > 0) {
+          providerRaw = {
+            provider: this.provider,
+            model: this.model,
+            wireApi: this.wireApi,
+            output: rawParts,
+          };
+        }
+        for (const part of rawParts) {
+          if (typeof part.text === "string") {
+            content.push({ type: "text", text: part.text });
+            continue;
+          }
+          const call =
+            part.functionCall && typeof part.functionCall === "object"
+              ? part.functionCall as Record<string, unknown>
+              : undefined;
+          if (call && typeof call.name === "string") {
+            content.push({
+              type: "tool_use",
+              id: typeof call.id === "string" ? call.id : `google-call-${++googleFunctionCallSequence}`,
+              name: call.name,
+              input:
+                call.args && typeof call.args === "object" && !Array.isArray(call.args)
+                  ? call.args as Record<string, unknown>
+                  : {},
+            });
+          }
+        }
+        const finishReason = String(candidate?.finishReason ?? "").toUpperCase();
+        stopReason = content.some((block) => block.type === "tool_use")
+          ? "tool_use"
+          : finishReason === "MAX_TOKENS"
+            ? "max_tokens"
+            : "end_turn";
+        if (json.usageMetadata) {
+          usage = {
+            inputTokens: json.usageMetadata.promptTokenCount ?? 0,
+            outputTokens: json.usageMetadata.candidatesTokenCount ?? 0,
           };
         }
       } else {

--- a/packages/core/src/stages/hunt-cross-family.test.ts
+++ b/packages/core/src/stages/hunt-cross-family.test.ts
@@ -64,6 +64,7 @@ const AUTH_VARS = [
   "KIMI_API_KEY",
   "QWEN_API_KEY",
   "XAI_API_KEY",
+  "OPENCODE_API_KEY",
   "0SEC_HUNT_REFUTER_CANDIDATES",
   "0SEC_HUNT_CROSS_FAMILY",
 ] as const;
@@ -148,6 +149,28 @@ describe("refuterFamily", () => {
     });
     expect(choice.crossFamily).toBe(false);
     expect(choice.status).toBe("no-distinct-family");
+  });
+
+  it("classifies Muse Spark as its own family, so OpenCode Zen can serve as a refuter", () => {
+    // Same regression shape as the Grok guard above: without the
+    // modelProvider mapping this answers "unknown" and the roster entry is a
+    // silent no-op.
+    expect(refuterFamily("muse-spark-1.3-contributor-free")).toBe("opencode");
+    expect(refuterFamily("opencode/mimo-v2.5-free")).toBe("opencode");
+  });
+
+  it("picks Muse Spark to decorrelate from a GPT finder", () => {
+    withProviders({ OPENCODE_API_KEY: "zen-test" });
+    expect(availableRefuterCandidates()).toEqual(["muse-spark-1.3-contributor-free"]);
+    const choice = selectCrossFamilyRefuter({
+      enabled: true,
+      finderModel: "gpt-5.5",
+      candidates: availableRefuterCandidates(),
+    });
+    expect(choice.crossFamily).toBe(true);
+    expect(choice.status).toBe("enforced");
+    expect(choice.model).toBe("muse-spark-1.3-contributor-free");
+    expect(choice.refuterFamily).toBe("opencode");
   });
 
   it("unwraps the openrouter/ routing prefix — same weights are NOT a second family", () => {

--- a/packages/core/src/stages/hunt-cross-family.ts
+++ b/packages/core/src/stages/hunt-cross-family.ts
@@ -117,6 +117,7 @@ const REFUTER_ROSTER: ReadonlyArray<{ model: string; envKeys: readonly string[] 
   { model: "k3", envKeys: ["KIMI_API_KEY"] },
   { model: "qwen3.8-max", envKeys: ["QWEN_API_KEY"] },
   { model: "grok-4.6", envKeys: ["XAI_API_KEY"] },
+  { model: "muse-spark-1.3-contributor-free", envKeys: ["OPENCODE_API_KEY"] },
 ];
 
 /**

--- a/packages/shared/src/pricing.ts
+++ b/packages/shared/src/pricing.ts
@@ -57,6 +57,15 @@ export const MANUAL_PRICING: Record<string, ModelRates> = {
   // credit-billed variant whose per-credit rate Alibaba does not publish.
   "qwen3.8-max": { input: 2.00, output: 6.00 },
   "qwen3.7-max": { input: 2.50, output: 7.50 },
+  // OpenCode Zen free tier (https://opencode.ai/docs/zen/) — zero-rate gateway
+  // models; actual spend is $0 while the free period lasts.
+  "muse-spark-1.3-contributor-free": { input: 0, output: 0 },
+  "muse-spark-1.2-contributor-free": { input: 0, output: 0 },
+  "mimo-v2.5-free": { input: 0, output: 0 },
+  "ling-3.0-flash-fin-free": { input: 0, output: 0 },
+  "big-pickle": { input: 0, output: 0 },
+  "nemotron-3-ultra-free": { input: 0, output: 0 },
+  "nemotron-3.5-lightning-free": { input: 0, output: 0 },
   // xAI Grok (docs.x.ai/developers/pricing, checked 2026-08-22) — SHORT-CONTEXT
   // rates only. xAI charges a second, higher tier once a request's prompt
   // crosses 200k tokens (grok-4.6: $4.00/$12.00 vs the $2.00/$6.00 below;
@@ -132,6 +141,7 @@ function normalizeModel(model: string): string {
     "kimi/",
     "moonshot/",
     "openrouter/",
+    "opencode/",
   ];
   for (const prefix of prefixes) {
     if (model.startsWith(prefix)) return model.slice(prefix.length);
@@ -178,6 +188,7 @@ export function modelProvider(model?: string): string {
   if (lowered.startsWith("z-ai/") || lowered.startsWith("zai/")) return "z-ai";
   if (lowered.startsWith("kimi/") || lowered.startsWith("moonshot/")) return "kimi";
   if (lowered.startsWith("openrouter/")) return "openrouter";
+  if (lowered.startsWith("opencode/")) return "opencode";
   if (lowered.startsWith("xai/") || lowered.startsWith("x-ai/")) return "xai";
 
   const stripped = normalizeModel(model).toLowerCase();
@@ -191,6 +202,7 @@ export function modelProvider(model?: string): string {
   if (stripped.startsWith("k3") || stripped.startsWith("kimi")) return "kimi";
   if (stripped.startsWith("qwen")) return "qwen";
   if (stripped.startsWith("grok")) return "xai";
+  if (/^(muse-spark|mimo|ling|big-pickle|nemotron|minimax)/.test(stripped)) return "opencode";
   return "unknown";
 }
 

--- a/packages/shared/src/pricing.ts
+++ b/packages/shared/src/pricing.ts
@@ -60,7 +60,6 @@ export const MANUAL_PRICING: Record<string, ModelRates> = {
   // OpenCode Zen free tier (https://opencode.ai/docs/zen/) — zero-rate gateway
   // models; actual spend is $0 while the free period lasts.
   "muse-spark-1.3-contributor-free": { input: 0, output: 0 },
-  "muse-spark-1.2-contributor-free": { input: 0, output: 0 },
   "mimo-v2.5-free": { input: 0, output: 0 },
   "ling-3.0-flash-fin-free": { input: 0, output: 0 },
   "big-pickle": { input: 0, output: 0 },


### PR DESCRIPTION
## Problem

#34 requests OpenCode as a supported provider + Zen-exclusive families (`muse-spark-*`, `mimo*`, `ling*`, `big-pickle`, `nemotron*`, `minimax-*`) 

## Change

- Route `opencode/*` + the Zen-exclusive families to a new `opencode` provider (`OPENCODE_API_KEY`, `OPENCODE_BASE_URL` override, default `https://opencode.ai/zen/v1`, default `muse-spark-1.3-contributor-free`). 
- Handle Zen's split wire: GPT/Grok/Muse Spark are served on `/responses`, everything else (DeepSeek/GLM/Kimi/MiniMax + free tier) on `/chat/completions`. `opencodeWireApiForModel()` picks per model and defaults to `chat_completions`, so new free models work without a code change; new Responses families need one regex entry.
- Zero-rate the 7 free-tier ids in pricing and map them in `modelProvider`.
- Docs: provider row and routing table in `api-keys.md`.

Manual check: `export OPENCODE_API_KEY=...`, then test with model `muse-spark-1.3-contributor-free` (responses wire) and `--model nemotron-3.5-lightning-free` (chat/completions wire).

## Verification

- `vitest run src/agent/cost.test.ts src/runtime/llm-api.test.ts src/stages/hunt-cross-family.test.ts` (@0sec/core) — 158 passed, 1 skipped.
- `vitest run src/tui/connection-recovery.test.ts src/tui/provider-status.test.ts` (cli) — 22 passed.
- Full `pnpm test` — 8 timeouts in `agentic-scanner.events`, `agentic-scanner.scope-guard`, `unified-pipeline.codex-runtime`, `unified-pipeline.novelty`, `unified-pipeline.verify-resume`; identical 8 fail on the clean tree with this branch stashed, so pre-existing and unrelated. No credentials committed (tests use `zen-test` fixtures).

## Known limitation

The model catalog listing conflicts with the pricing filter and still behaves incorrectly. This affects all provider model catalogs and is **unrelated to the changes introduced in this PR**. I’ll address it in a follow-up PR.
