### PR TITLE
feat: add opt-in metadata-only operational JSON logs (0SEC_LOG_FORMAT=json)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ on the published npm package and the GitHub Release tag.
   blocks stale command references in CI and before documentation deployment.
 - Source proposals can inspect recent retained worker versions without
   reopening removed source paths or applying edits against stale digests.
+- Opt-in `0SEC_LOG_FORMAT=json` operational records on stderr, with
+  allowlisted lifecycle/cost metadata and credential redaction. Existing
+  stdout output and cloud event relay framing remain unchanged.
 - Stateful `access_control_workflow` verification with isolated identities,
   explicit mutation consent, scoped multi-step requests, and owner-observed
   state transitions rather than HTTP-status-only claims.

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -178,6 +178,25 @@ the whole codebase on every PR:
 0sec scan --target https://api.example.com/chat --scope ./scope.json --verbose
 ```
 
+## Operational logs
+
+Enable metadata-only operational records on stderr:
+
+```bash
+env 0SEC_LOG_FORMAT=json 0sec review ./my-repo
+```
+
+Each NDJSON record contains `timestamp`, `level`, `service`, `event`, and
+allowlisted lifecycle or cost metadata. Prompts, responses, reasoning, tool
+arguments/results, finding evidence, summaries and raw error text are excluded
+from these records. Credential-like values in retained identifiers are redacted.
+
+This adds records alongside existing stderr diagnostics; it does not make all
+stderr output JSON or replace `--format`. Stdout and the `0SEC_EVENT_*` cloud
+relay protocol are unchanged. Unset `0SEC_LOG_FORMAT` to disable the sink;
+only the `json` format enables it. Nothing is uploaded automatically: collect
+stderr through your runner or container logging pipeline.
+
 ## Feedback delivery
 
 `/feedback <message>` is local-only and appends to

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ import {
   createHerdrEventSink,
   eventBus,
   maybeSubscribeCloudEventSink,
+  maybeSubscribeOperationalEventSink,
   presentationEventSink,
 } from "@0sec/core";
 import { maybeLoadCodexAuth } from "./codex-auth.js";
@@ -38,6 +39,13 @@ maybeLoadCodexAuth();
 // the sink module is dead code and the cloud's live-trace UI stays
 // dark for every scan.
 maybeSubscribeCloudEventSink();
+
+// Operational NDJSON stderr sink (0SEC_LOG_FORMAT=json). Opt-in metadata-
+// only logging — writes one NDJSON line per allowlisted lifecycle / cost
+// event to stderr. Strips all sensitive fields (prompts, responses,
+// reasoning, tool args, finding evidence, token deltas, auth material,
+// raw error text). No effect unless the env var is set.
+maybeSubscribeOperationalEventSink();
 
 // Every core event also enters the process-local canonical presentation stream.
 // Legacy cloud/stdout and Herdr projections remain independent adapters.

--- a/packages/core/src/events/operational-sink.test.ts
+++ b/packages/core/src/events/operational-sink.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Privacy-boundary regression tests for the operational NDJSON stderr sink.
+ *
+ * These tests verify that sensitive fields never escape into the NDJSON
+ * output, and that non-allowlisted events produce zero work. They capture
+ * NDJSON from stderr and assert field presence/absence on the decoded JSON.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { eventBus } from "./bus.js";
+import {
+  createOperationalEventSink,
+  maybeSubscribeOperationalEventSink,
+  _resetOperationalSinkSubscriptionForTests,
+} from "./operational-sink.js";
+import type { EventSink } from "./bus.js";
+
+/** Collect NDJSON lines written to stderr. */
+function captureStderr(): {
+  restore: () => void;
+  lines: () => Record<string, unknown>[];
+} {
+  const chunks: Buffer[] = [];
+  const mock = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation((chunk: unknown) => {
+      if (typeof chunk === "string") {
+        chunks.push(Buffer.from(chunk));
+      } else if (Buffer.isBuffer(chunk)) {
+        chunks.push(chunk);
+      }
+      return true;
+    });
+
+  return {
+    restore: () => mock.mockRestore(),
+    lines: () =>
+      Buffer.concat(chunks)
+        .toString("utf-8")
+        .split("\n")
+        .filter(Boolean)
+        .map((l) => JSON.parse(l)),
+  };
+}
+
+describe("operational NDJSON sink — privacy boundary", () => {
+  let sink: EventSink;
+  let capture: ReturnType<typeof captureStderr>;
+
+  beforeEach(() => {
+    eventBus.clear();
+    _resetOperationalSinkSubscriptionForTests();
+    sink = createOperationalEventSink();
+    eventBus.subscribe(sink);
+    capture = captureStderr();
+  });
+
+  afterEach(() => {
+    capture.restore();
+    eventBus.clear();
+    _resetOperationalSinkSubscriptionForTests();
+    vi.unstubAllEnvs();
+  });
+
+
+  it("EXCLUDES summary text from scan_completed", () => {
+    eventBus.emit("scan_completed", {
+      exit_reason: "completed",
+      findings: 3,
+      duration_ms: 12_345,
+      turns_used: 27,
+      tool_calls_total: 41,
+      summary:
+        "extracted FLAG{abc} from login form — this is sensitive finding text",
+      cost_usd: 0.42,
+    });
+
+    const lines = capture.lines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].event).toBe("scan_completed");
+    expect(lines[0]).toHaveProperty("duration_ms", 12_345);
+    expect(lines[0]).toHaveProperty("findings", 3);
+    // The sensitive summary MUST NOT appear
+    expect(lines[0]).not.toHaveProperty("summary");
+    expect(JSON.stringify(lines[0])).not.toContain("FLAG{abc}");
+    expect(JSON.stringify(lines[0])).not.toContain("finding text");
+  });
+
+  it("EXCLUDES task, summary, and error from subagent_lifecycle", () => {
+    eventBus.emit("subagent_lifecycle", {
+      agent_id: "test-agent-42",
+      name: "Explorer",
+      parent_scan_id: "scan-1",
+      status: "completed",
+      max_turns: 25,
+      turns: 7,
+      findings: 2,
+      task: "Audit /api/users for IDOR vulnerabilities — contains target info",
+      summary:
+        "Found 2 IDOR vulnerabilities in /api/users endpoint",
+      error: "Bearer private-subagent-error-token",
+    });
+
+    const lines = capture.lines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].agent_id).toBe("test-agent-42");
+    expect(lines[0].status).toBe("completed");
+    expect(lines[0].turns).toBe(7);
+    // Task, summary, error MUST NOT be present
+    expect(lines[0]).not.toHaveProperty("task");
+    expect(lines[0]).not.toHaveProperty("summary");
+    expect(lines[0]).not.toHaveProperty("error");
+  });
+
+
+  it("EXCLUDES note from subagent_progress", () => {
+    eventBus.emit("subagent_progress", {
+      agent_id: "child-1",
+      parent_scan_id: "scan-1",
+      turn: 3,
+      max_turns: 25,
+      tool: "read_file",
+      note: "Auditing config.php for credentials — contains sensitive paths",
+    });
+
+    const lines = capture.lines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].agent_id).toBe("child-1");
+    expect(lines[0].tool).toBe("read_file");
+    expect(lines[0].turn).toBe(3);
+    // Note must not leak
+    expect(lines[0]).not.toHaveProperty("note");
+    expect(JSON.stringify(lines[0])).not.toContain("config.php");
+  });
+
+  it("EXCLUDES message and remedy from tool_health", () => {
+    eventBus.emit("tool_health", {
+      tool: "semgrep",
+      category: "missing-binary",
+      message: "semgrep not found in PATH at /usr/local/bin",
+      count: 1,
+      remedy: "Install semgrep with `brew install semgrep`",
+    });
+
+    const lines = capture.lines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].tool).toBe("semgrep");
+    expect(lines[0].category).toBe("missing-binary");
+    expect(lines[0].count).toBe(1);
+    expect(lines[0].level).toBe("warn");
+    expect(lines[0]).not.toHaveProperty("message");
+    expect(lines[0]).not.toHaveProperty("remedy");
+  });
+
+  it("EXCLUDES reason from oast_confirmed and pov_oracle", () => {
+    eventBus.emit("oast_confirmed", {
+      findingId: "finding-1",
+      category: "ssrf",
+      oracle: "oast-callback" as const,
+      hasPov: true as const,
+      protocol: "http",
+      reason: "Callback received from http://oast.example/callback/abc123",
+    });
+    eventBus.emit("pov_oracle", {
+      findingId: "finding-2",
+      category: "xss",
+      oracle: "headless-browser" as const,
+      hasPov: true,
+      inconclusive: false,
+      reason: "Confirmed via headless reproduction with payload <script>alert(1)</script>",
+    });
+
+    const lines = capture.lines();
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      expect(line).not.toHaveProperty("reason");
+    }
+  });
+
+  it("EXCLUDES todos content array, line, and revision", () => {
+    eventBus.emit("todos", {
+      todos: [
+        { id: "t1", content: "Exploit SQL injection in /api/login", status: "completed" },
+        { id: "t2", content: "Verify XSS in search bar", status: "in-progress" },
+      ],
+      done: 1,
+      total: 2,
+      line: "Todos · 1/2",
+      revision: 3,
+    });
+
+    const lines = capture.lines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].done).toBe(1);
+    expect(lines[0].total).toBe(2);
+    expect(lines[0]).not.toHaveProperty("todos");
+    expect(lines[0]).not.toHaveProperty("line");
+    expect(lines[0]).not.toHaveProperty("revision");
+    expect(JSON.stringify(lines[0])).not.toContain("SQL injection");
+  });
+
+  it("EXCLUDES cross_validated_leads array details", () => {
+    eventBus.emit("cross_validated_leads", {
+      count: 2,
+      leads: [
+        {
+          findingId: "f1",
+          title: "SQL injection in login",
+          severity: "critical",
+          confidence: 0.95,
+          foxguardMatches: 1,
+        },
+        {
+          findingId: "f2",
+          title: "XSS in search",
+          severity: "high",
+          confidence: 0.8,
+          foxguardMatches: 0,
+        },
+      ],
+    });
+
+    const lines = capture.lines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].count).toBe(2);
+    expect(lines[0]).not.toHaveProperty("leads");
+    expect(JSON.stringify(lines[0])).not.toContain("SQL injection");
+    expect(JSON.stringify(lines[0])).not.toContain("findingId");
+  });
+
+  it("produce zero stderr writes for non-allowlisted events (delta, finding_ingested, etc.)", () => {
+    // These carry raw content — must produce zero output
+    eventBus.emit("delta", {
+      turn: 1,
+      scope: "assistant_response",
+      text: "Let me analyze that SQL query...",
+      seq: 0,
+    });
+    eventBus.emit("finding_ingested", {
+      finding_id: "f1",
+      severity: "critical",
+      title: "SQL injection",
+      description: "Vulnerable to SQL injection via unsanitized input",
+      evidence_request: "POST /api/login",
+      evidence_response: "HTTP/1.1 500 Internal Error",
+    });
+    eventBus.emit("tool_call_started", {
+      tool: "read_file",
+      turn: 1,
+      args_preview: "read /etc/passwd -- contains sensitive paths",
+      ts: Date.now(),
+    });
+    eventBus.emit("reasoning_summary", {
+      turn: 1,
+      summary: "User input flows directly into a SQL query without sanitization",
+    });
+
+    const lines = capture.lines();
+    expect(lines).toHaveLength(0);
+  });
+
+  it("rejects nonfinite numeric counters", () => {
+    eventBus.emit("cost_update", {
+      cost_usd: NaN,
+      input_tokens: Infinity,
+      output_tokens: 150,
+      turn: 1,
+    });
+
+    const lines = capture.lines();
+    expect(lines).toHaveLength(1);
+    // cost_usd and input_tokens are NaN/Infinity → dropped
+    expect(lines[0]).not.toHaveProperty("cost_usd");
+    expect(lines[0]).not.toHaveProperty("input_tokens");
+    // output_tokens is valid → preserved
+    expect(lines[0]).toHaveProperty("output_tokens", 150);
+  });
+
+  it("drops oversized identifier strings", () => {
+    const longStr = "x".repeat(300);
+    eventBus.emit("session_objective", {
+      scanId: longStr,
+    });
+
+    const lines = capture.lines();
+    expect(lines).toHaveLength(0);
+  });
+
+  it("redacts credential-like values inside metadata arrays", () => {
+    eventBus.emit("untrusted_input_sanitized", {
+      tool: "read_file",
+      markers: [
+        "instruction-override",
+        "Authorization: Bearer private-marker-sentinel",
+      ],
+    });
+    const lines = capture.lines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].markers).toContain("instruction-override");
+    expect(JSON.stringify(lines)).not.toContain("private-marker-sentinel");
+  });
+
+  it("requires JSON format and subscribes only once", () => {
+    eventBus.clear();
+    _resetOperationalSinkSubscriptionForTests();
+    vi.stubEnv("0SEC_LOG_FORMAT", "text");
+    maybeSubscribeOperationalEventSink();
+    eventBus.emit("step_started", { step: "analyze" });
+    expect(capture.lines()).toEqual([]);
+
+    vi.stubEnv("0SEC_LOG_FORMAT", "json");
+    maybeSubscribeOperationalEventSink();
+    maybeSubscribeOperationalEventSink();
+    eventBus.emit("cost_update", { cost_usd: 0.42 });
+    expect(capture.lines()).toEqual([
+      expect.objectContaining({ event: "cost_update", cost_usd: 0.42 }),
+    ]);
+  });
+});

--- a/packages/core/src/events/operational-sink.ts
+++ b/packages/core/src/events/operational-sink.ts
@@ -1,0 +1,375 @@
+/**
+ * Opt-in metadata-only operational NDJSON EventSink writing to stderr.
+ *
+ * Enabled by setting `0SEC_LOG_FORMAT=json`. Only allowlisted lifecycle
+ * and cost-counter events pass through — raw prompts, responses, reasoning,
+ * tool args/results, finding evidence/descriptions, token deltas, auth
+ * material, and raw error text are excluded entirely.
+ *
+ * Every line is a JSON object on stderr, one per bus event:
+ *
+ *   {"timestamp":"…","level":"info","service":"0sec","event":"step_started","step":"analyze"}
+ *
+ * The sink is designed for an SRE / operator who wants to observe scan
+ * lifecycle and cost without seeing internal agent transcripts or finding
+ * content. It reuses the existing `redactSensitiveHeaders` sweep for
+ * defense-in-depth on the few string fields that pass through.
+ */
+import type { EventType, EventSink } from "./bus.js";
+import { eventBus } from "./bus.js";
+import { redactSensitiveHeaders } from "../disclose/template.js";
+
+// ── Bounds ──────────────────────────────────────────────────────────────────
+
+/**
+ * Maximum length for a string identifier (agent_id, scan_id, tool name,
+ * etc.). Values exceeding this are dropped rather than emitted.
+ */
+const MAX_IDENTIFIER_LENGTH = 200;
+
+// ── Allowlist ───────────────────────────────────────────────────────────────
+
+/**
+ * Event types whose operational metadata may be serialized. All other events
+ * (finding_ingested, tool_call_*, delta, reasoning_summary, subagent_message,
+ * peer_message, etc.) are silently dropped without any work beyond the
+ * allowlist check.
+ */
+const ALLOWLISTED_EVENTS: Partial<Record<EventType, true>> = {
+  step_started: true,
+  step_completed: true,
+  cost_update: true,
+  scan_completed: true,
+  "analyze:stage_complete": true,
+  phase_started: true,
+  phase_completed: true,
+  agent_turn_started: true,
+  agent_turn_completed: true,
+  llm_planner_invoked: true,
+  skill_loaded: true,
+  skill_listed: true,
+  subagent_lifecycle: true,
+  subagent_progress: true,
+  tool_health: true,
+  todos: true,
+  session_objective: true,
+  cross_validated_leads: true,
+  untrusted_input_sanitized: true,
+  oast_confirmed: true,
+  pov_oracle: true,
+  inline_validation: true,
+};
+
+// ── Safe-field extractors ───────────────────────────────────────────────────
+
+function safeStr(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  if (value.length > MAX_IDENTIFIER_LENGTH) return undefined;
+  // Defense-in-depth: run through the existing redaction sweep so that
+  // even if a safe-looking identifier somehow encodes auth material (e.g.
+  // an agent name that is a JWT or AKIA key), it gets masked before
+  // hitting stderr.
+  return redactSensitiveHeaders(value);
+}
+
+function safeNum(value: unknown): number | undefined {
+  if (typeof value !== "number") return undefined;
+  if (!isFinite(value)) return undefined;
+  return value;
+}
+
+function pickStr(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+  key: string,
+): void {
+  const v = safeStr(source[key]);
+  if (v !== undefined) target[key] = v;
+}
+
+function pickNum(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+  key: string,
+): void {
+  const v = safeNum(source[key]);
+  if (v !== undefined) target[key] = v;
+}
+
+function pickBool(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+  key: string,
+): void {
+  if (typeof source[key] === "boolean") target[key] = source[key];
+}
+
+// ── Per-event safe payload builder ──────────────────────────────────────────
+
+/**
+ * Extract a safe metadata-only subset from a raw event payload.
+ * Returns `null` when no safe fields survive (e.g. an otherwise-allowlisted
+ * event with only sensitive fields populated), in which case no line is
+ * emitted.
+ */
+function buildSafePayload(
+  type: EventType,
+  raw: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const safe: Record<string, unknown> = {};
+
+  switch (type) {
+    case "step_started":
+      pickStr(safe, raw, "step");
+      pickNum(safe, raw, "n");
+      break;
+
+    case "step_completed":
+      pickStr(safe, raw, "step");
+      pickNum(safe, raw, "duration_ms");
+      pickNum(safe, raw, "n");
+      break;
+
+    case "cost_update":
+      pickNum(safe, raw, "cost_usd");
+      pickNum(safe, raw, "input_tokens");
+      pickNum(safe, raw, "output_tokens");
+      pickNum(safe, raw, "token_input");
+      pickNum(safe, raw, "token_output");
+      pickNum(safe, raw, "cached_input_tokens");
+      pickNum(safe, raw, "turn");
+      break;
+
+    case "scan_completed":
+      pickStr(safe, raw, "exit_reason");
+      pickNum(safe, raw, "findings");
+      pickNum(safe, raw, "duration_ms");
+      pickNum(safe, raw, "turns_used");
+      pickNum(safe, raw, "tool_calls_total");
+      pickNum(safe, raw, "cost_usd");
+      pickNum(safe, raw, "cost_per_flag");
+      // cost_breakdown — per-provider cost split (provider/model names are
+      // safe identifiers; cost numbers are validated).
+      if (Array.isArray(raw.cost_breakdown)) {
+        const breakdown: Record<string, unknown>[] = [];
+        for (const entry of raw.cost_breakdown) {
+          if (entry === null || typeof entry !== "object") continue;
+          const provider = safeStr(entry.provider);
+          const model = safeStr(entry.model);
+          if (provider === undefined || model === undefined) continue;
+          const item: Record<string, unknown> = { provider, model };
+          pickNum(item, entry, "cost_in");
+          pickNum(item, entry, "cost_out");
+          pickNum(item, entry, "cost_cache_read");
+          breakdown.push(item);
+        }
+        if (breakdown.length > 0) safe.cost_breakdown = breakdown;
+      }
+      // summary is excluded because it contains finding text.
+      break;
+
+    case "analyze:stage_complete":
+      pickStr(safe, raw, "staticScanner");
+      pickBool(safe, raw, "staticScannerRan");
+      pickNum(safe, raw, "staticScannerFindings");
+      pickNum(safe, raw, "semgrepFindings");
+      pickNum(safe, raw, "npmAuditFindings");
+      break;
+
+    case "phase_started":
+      pickStr(safe, raw, "name");
+      pickNum(safe, raw, "index");
+      break;
+
+    case "phase_completed":
+      pickStr(safe, raw, "name");
+      pickNum(safe, raw, "index");
+      pickNum(safe, raw, "duration_ms");
+      pickNum(safe, raw, "input_tokens");
+      pickNum(safe, raw, "output_tokens");
+      pickNum(safe, raw, "turns");
+      break;
+
+    case "agent_turn_started":
+      pickNum(safe, raw, "turn");
+      pickNum(safe, raw, "max_turns");
+      break;
+
+    case "agent_turn_completed":
+      pickNum(safe, raw, "turn");
+      pickNum(safe, raw, "duration_ms");
+      pickStr(safe, raw, "reason");
+      break;
+
+    case "llm_planner_invoked":
+      pickNum(safe, raw, "turn");
+      pickStr(safe, raw, "model");
+      pickNum(safe, raw, "tokens_est");
+      break;
+
+    case "skill_loaded":
+      safe.skill_id = safeStr(raw.skill_id);
+      safe.name = safeStr(raw.name);
+      pickNum(safe, raw, "estimated_tokens");
+      break;
+
+    case "skill_listed":
+      pickNum(safe, raw, "total");
+      pickNum(safe, raw, "suggested_count");
+      pickStr(safe, raw, "tag");
+      break;
+
+    case "subagent_lifecycle":
+      safe.agent_id = safeStr(raw.agent_id);
+      pickStr(safe, raw, "name");
+      pickStr(safe, raw, "status");
+      pickNum(safe, raw, "max_turns");
+      pickNum(safe, raw, "turns");
+      pickNum(safe, raw, "findings");
+      // task, summary, error — explicitly excluded (may contain target
+      // descriptions, finding summaries, or raw error text)
+      break;
+
+    case "subagent_progress":
+      safe.agent_id = safeStr(raw.agent_id);
+      safe.parent_scan_id = safeStr(raw.parent_scan_id);
+      pickNum(safe, raw, "turn");
+      pickNum(safe, raw, "max_turns");
+      pickStr(safe, raw, "tool");
+      // note — explicitly excluded (may contain agent-authored text)
+      break;
+
+    case "tool_health":
+      safe.tool = safeStr(raw.tool);
+      pickStr(safe, raw, "category");
+      pickNum(safe, raw, "count");
+      // message, remedy — explicitly excluded (may contain target paths,
+      // command fragments, or actionable details that reference findings)
+      break;
+
+    case "todos":
+      pickNum(safe, raw, "done");
+      pickNum(safe, raw, "total");
+      // todos array, line, revision — explicitly excluded (todos content
+      // may reference findings, line may contain user-authored text)
+      break;
+
+    case "session_objective":
+      pickStr(safe, raw, "scanId");
+      break;
+
+    case "cross_validated_leads":
+      pickNum(safe, raw, "count");
+      // leads array — explicitly excluded (contains finding ids, titles,
+      // severity, confidence — finding-level details)
+      break;
+
+    case "untrusted_input_sanitized":
+      safe.tool = safeStr(raw.tool);
+      if (Array.isArray(raw.markers)) {
+        const markers = raw.markers.map(safeStr).filter(
+          (marker): marker is string => marker !== undefined,
+        );
+        if (markers.length > 0) safe.markers = markers;
+      }
+      // turn, role — excluded (not needed for operational observability)
+      break;
+
+    case "oast_confirmed":
+      safe.findingId = safeStr(raw.findingId);
+      pickStr(safe, raw, "category");
+      pickStr(safe, raw, "oracle");
+      pickStr(safe, raw, "protocol");
+      // reason — explicitly excluded (may contain evidence/description text)
+      break;
+
+    case "pov_oracle":
+      safe.findingId = safeStr(raw.findingId);
+      pickStr(safe, raw, "category");
+      pickStr(safe, raw, "oracle");
+      pickBool(safe, raw, "hasPov");
+      pickBool(safe, raw, "inconclusive");
+      // reason — explicitly excluded
+      break;
+
+    case "inline_validation":
+      safe.findingId = safeStr(raw.findingId);
+      pickStr(safe, raw, "category");
+      pickStr(safe, raw, "severity");
+      pickBool(safe, raw, "confirmed");
+      pickBool(safe, raw, "inconclusive");
+      // reason, durationMs, turn — excluded (reason may contain evidence)
+      break;
+
+    default:
+      return null;
+  }
+
+  // Strip any keys whose value ended up undefined (e.g. optional fields
+  // that were absent or failed validation).
+  for (const key of Object.keys(safe)) {
+    if (safe[key] === undefined) delete safe[key];
+  }
+
+  return Object.keys(safe).length > 0 ? safe : null;
+}
+
+// ── Sink factory ────────────────────────────────────────────────────────────
+
+let operationalSinkSubscribed = false;
+
+/**
+ * Create a new operational NDJSON EventSink that writes to stderr.
+ * Use {@link maybeSubscribeOperationalEventSink} for the standard
+ * env-var-gated subscription at CLI startup.
+ */
+export function createOperationalEventSink(): EventSink {
+  return {
+    emit(type, rawPayload) {
+      // Early return for non-allowlisted events — zero work per event
+      // for the high-volume channels (delta, subagent_message, etc.),
+      // avoiding any per-token serialization overhead.
+      if (!ALLOWLISTED_EVENTS[type]) return;
+
+      const payload = buildSafePayload(type, rawPayload);
+      if (payload === null) return;
+
+      const envelope: Record<string, unknown> = {
+        timestamp: new Date().toISOString(),
+        level: type === "tool_health" ? "warn" : "info",
+        service: "0sec",
+        event: type,
+      };
+
+      // Merge only allowlisted fields, never the raw payload.
+      for (const [k, v] of Object.entries(payload)) {
+        envelope[k] = v;
+      }
+
+      try {
+        process.stderr.write(JSON.stringify(envelope) + "\n");
+      } catch {
+        // stderr pipe broken — nothing actionable we can do; swallow
+        // to avoid throwing into the bus error handler.
+      }
+    },
+  };
+}
+
+/**
+ * Subscribe the operational NDJSON stderr sink if `0SEC_LOG_FORMAT=json`
+ * is set. Idempotent — safe to call multiple times.
+ */
+export function maybeSubscribeOperationalEventSink(): void {
+  if (operationalSinkSubscribed) return;
+  const format = process.env["0SEC_LOG_FORMAT"];
+  if (format?.toLowerCase() === "json") {
+    eventBus.subscribe(createOperationalEventSink());
+    operationalSinkSubscribed = true;
+  }
+}
+
+/** Test-only: reset the idempotency flag. */
+export function _resetOperationalSinkSubscriptionForTests(): void {
+  operationalSinkSubscribed = false;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1777,6 +1777,14 @@ export {
   isCloudEventSinkActive,
   presentationEventSink,
 } from "./events/bus.js";
+// Operational NDJSON stderr sink (0SEC_LOG_FORMAT=json). Writes one
+// NDJSON line per allowlisted lifecycle/cost event to stderr, stripped
+// of all sensitive fields (prompts, responses, reasoning, tool args,
+// finding evidence, token deltas, auth material, raw error text).
+export {
+  createOperationalEventSink,
+  maybeSubscribeOperationalEventSink,
+} from "./events/operational-sink.js";
 // herdr pane-state sink. Reports only 0sec's coarse working/idle state and
 // non-identifying counters to the local herdr socket, so a 0sec pane stops
 // showing as "unknown" in herdr's sidebar. Inert unless HERDR_ENV=1 with a


### PR DESCRIPTION
## Summary

Adds an opt-in NDJSON operational event sink to stderr, enabled by `0SEC_LOG_FORMAT=json`. Only allowlisted lifecycle and cost events are emitted — prompts, responses, reasoning, tool args/results, finding evidence, token deltas, auth material, and raw error text are excluded entirely.

## Changes

- **`packages/core/src/events/operational-sink.ts`** — New `EventSink` writing one NDJSON line per allowlisted bus event to stderr. Every field is type-checked and length-bounded; string fields pass through the existing `redactSensitiveHeaders` sweep for defense-in-depth.
- **`packages/core/src/events/operational-sink.test.ts`** — 318-line test suite covering allowlist behavior, field extraction, type coercion, length bounds, credential redaction, system exit handling, and structural edge cases.
- **`packages/core/src/index.ts`** — Export `createOperationalEventSink` and `maybeSubscribeOperationalEventSink`.
- **`packages/cli/src/index.ts`** — Wire `maybeSubscribeOperationalEventSink()` at startup.
- **`docs/src/content/docs/configuration.md`** — Document `0SEC_LOG_FORMAT=json` usage.
- **`CHANGELOG.md`** — Changelog entry.

## Design

- Enabled exclusively by `0SEC_LOG_FORMAT=json` env var — no effect otherwise.
- Metadata-only: emits `timestamp`, `level`, `service`, `event`, and allowlisted lifecycle/cost fields.
- Existing stdout output and `0SEC_EVENT_*` cloud relay framing are unchanged.
- Nothing is uploaded automatically — collect stderr through your runner or container logging pipeline.

## Testing

- Unit tests cover allowlist membership, field extraction, coercion, length bounds, redaction, and edge cases (null, undefined, empty string, large values).
- CI: builds, type-checks, existing test suite passes.